### PR TITLE
fix: clip batch input sample update

### DIFF
--- a/examples/sample-clip-batch-input.csv
+++ b/examples/sample-clip-batch-input.csv
@@ -1,2 +1,2 @@
 286076113143433cb5f2655c5f70a30e,the cat is in my house,,
-386076113143433cb5f2655c5f70a30e,the dog is in my house,,
+386076113143433cb5f2655c5f70a30e,,https://dummyimage.com/333/000/fff.jpg&text=embed+this,


### PR DESCRIPTION
If proper access control setup can be added to Batch Transform ([ref](https://github.com/jina-ai/jina-sagemaker/blob/main/notebooks/Embedding%20using%20batch%20transform.ipynb)) , we can actually put image URL in input CSV for Batch Transform when using `jina-clip-v1`.