### PR TITLE
fix: harden Client (model dispatch, region, logging, transform guard)

### DIFF
--- a/jina_sagemaker/client.py
+++ b/jina_sagemaker/client.py
@@ -1,17 +1,24 @@
+"""Jina SageMaker client.
+
+Provides the high-level :class:`Client` for interacting with Jina model
+endpoints deployed on AWS SageMaker — real-time inference, batch transform,
+asynchronous inference, and endpoint lifecycle management.
+"""
+
 import json
 import logging
 import os
 import time
 import uuid
+from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import boto3
 from botocore.exceptions import ClientError, ParamValidationError
 
 from .helper import download_s3_folder, get_role, prefix_csv_with_ids
 
-logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
 
@@ -28,6 +35,83 @@ class Task(Enum):
     SEPARATION = "separation"
 
 
+@dataclass(frozen=True)
+class ModelSpec:
+    """Captures the request-payload conventions of a Jina SageMaker model.
+
+    The ``family`` field is the single source of truth for payload-shape
+    decisions in :meth:`Client.embed`, :meth:`Client.rerank`, and
+    :meth:`Client.read`. Callers should never re-parse the ARN to make these
+    decisions; do them via ``self._model_spec`` instead.
+    """
+
+    name: str
+    family: str
+    reader_model: Optional[str] = None
+
+
+# Ordered detection table. The first slug that appears as a substring of the
+# ARN wins, so longer / more-specific slugs come first to prevent collisions
+# (e.g. ``jina-reranker-m0`` must come before the generic ``jina-reranker``
+# entry, and ``jina-embeddings-v4`` before ``jina-embeddings``).
+_DETECTION_TABLE: List[Tuple[str, ModelSpec]] = [
+    ("jina-reranker-m0", ModelSpec("jina-reranker-m0", "reranker-m0")),
+    ("jina-embeddings-v4", ModelSpec("jina-embeddings-v4", "embeddings-v4")),
+    ("jina-embeddings-v3", ModelSpec("jina-embeddings-v3", "embeddings-v3")),
+    ("jina-clip-v2", ModelSpec("jina-clip-v2", "clip-v2")),
+    (
+        "ReaderLM-v2",
+        ModelSpec("ReaderLM-v2", "reader-lm", reader_model="ReaderLM-v2"),
+    ),
+    (
+        "1500m",
+        ModelSpec("reader-lm-1.5b", "reader-lm", reader_model="reader-lm-1.5b"),
+    ),
+    (
+        "reader-lm-500m",
+        ModelSpec("reader-lm-0.5b", "reader-lm", reader_model="reader-lm-0.5b"),
+    ),
+    ("jina-reranker", ModelSpec("jina-reranker", "reranker")),
+    ("jina-colbert", ModelSpec("jina-colbert", "colbert")),
+    ("jina-embeddings", ModelSpec("jina-embeddings", "embeddings-default")),
+]
+
+
+# Accepts the canonical ``ModelSpec.name`` as an explicit override when the
+# caller passes ``model=`` to ``connect_to_endpoint`` / ``create_endpoint`` /
+# ``create_async_endpoint``. The override path skips ARN detection entirely.
+_OVERRIDE_TABLE: Dict[str, ModelSpec] = {
+    spec.name: spec for _, spec in _DETECTION_TABLE
+}
+
+
+def _resolve_model(arn: str, override: Optional[str] = None) -> ModelSpec:
+    """Return the :class:`ModelSpec` for ``arn``, or for ``override`` if set.
+
+    ``override`` must be a known canonical model name when supplied;
+    unknown values raise :class:`ValueError` at connect time so the customer
+    sees the problem immediately instead of getting a malformed payload at
+    inference time.
+
+    When ``override`` is ``None`` the ARN is matched against the detection
+    table in order. An ARN that matches nothing falls back to
+    ``embeddings-default`` — same behaviour as the pre-refactor substring
+    matching.
+    """
+    if override is not None:
+        if override not in _OVERRIDE_TABLE:
+            known = sorted(_OVERRIDE_TABLE)
+            raise ValueError(
+                f"Unknown model override {override!r}. Known values: {known}"
+            )
+        return _OVERRIDE_TABLE[override]
+
+    for slug, spec in _DETECTION_TABLE:
+        if slug in arn:
+            return spec
+    return ModelSpec(arn, "embeddings-default")
+
+
 class Client:
     def __init__(
         self,
@@ -36,22 +120,36 @@ class Client:
     ):
         import sagemaker
 
-        client_args = client_args or {}
+        client_args = dict(client_args or {})
         if region_name:
             client_args["region_name"] = region_name
+        # Stored so methods that build their own boto3 clients (e.g.
+        # ``read_async``'s ad-hoc S3 client) reuse the same region and
+        # credentials.
+        self._client_args = client_args
 
         self._sm_runtime_client = boto3.client("sagemaker-runtime", **client_args)
         self._sm_client = boto3.client("sagemaker", **client_args)
+        # Thread region_name into the boto3 Session so the high-level sagemaker
+        # SDK honours the customer-supplied region instead of silently falling
+        # back to AWS_DEFAULT_REGION.
         self._sm_session = sagemaker.Session(
-            boto_session=boto3.Session(),
+            boto_session=boto3.Session(region_name=client_args.get("region_name")),
             sagemaker_client=self._sm_client,
         )
         self._aas_client = boto3.client("application-autoscaling", **client_args)
         self._cw_client = boto3.client("cloudwatch", **client_args)
 
-        self._endpoint_name = None
-        self._endpoint_config_name = None
-        self._model_name = None
+        self._endpoint_name: Optional[str] = None
+        self._endpoint_config_name: Optional[str] = None
+        self._model_name: Optional[str] = None
+        # Connected-state attrs initialised here so methods called before
+        # ``connect_to_endpoint`` raise the explicit "No endpoint connected"
+        # message instead of AttributeError.
+        self._variant_name: Optional[str] = None
+        self._resource_id: Optional[str] = None
+        self._arn: Optional[str] = None
+        self._model_spec: Optional[ModelSpec] = None
 
     def _does_endpoint_exist(self, endpoint_name: str) -> bool:
         try:
@@ -60,7 +158,26 @@ class Client:
             return False
         return True
 
-    def connect_to_endpoint(self, endpoint_name: str, arn: str) -> None:
+    def connect_to_endpoint(
+        self,
+        endpoint_name: str,
+        arn: str,
+        *,
+        model: Optional[str] = None,
+    ) -> None:
+        """Connect this client to an existing SageMaker endpoint.
+
+        Args:
+            endpoint_name: Name of the deployed SageMaker endpoint.
+            arn: The model package ARN backing the endpoint.
+            model: Optional explicit model identifier (e.g.
+                ``"jina-embeddings-v3"``, ``"ReaderLM-v2"``) that bypasses ARN
+                substring detection. Use this when a custom or future ARN
+                format prevents auto-detection from picking the correct
+                request shape. Must be one of the known canonical model
+                names; otherwise a :class:`ValueError` is raised here at
+                connect time.
+        """
         if not self._does_endpoint_exist(endpoint_name):
             raise Exception(f"Endpoint {endpoint_name} does not exist.")
         self._endpoint_name = endpoint_name
@@ -69,6 +186,7 @@ class Client:
             self._endpoint_name, self._variant_name
         )
         self._arn = arn
+        self._model_spec = _resolve_model(arn, override=model)
 
     def create_async_endpoint(
         self,
@@ -84,26 +202,29 @@ class Client:
         wait: bool = True,
         poll_interval: int = 30,
         timeout: int = 3600,
+        *,
+        model: Optional[str] = None,
     ) -> None:
-        """
-        Creates an asynchronous SageMaker endpoint from a model package ARN.
+        """Create an asynchronous SageMaker endpoint from a model package ARN.
 
         Args:
-            arn (str): The model package ARN.
-            endpoint_name (str): The name of the endpoint.
-            s3_output_path (str): S3 path where the asynchronous inference results will be stored.
-            instance_type (str): The instance type for the endpoint (e.g., "ml.m5.xlarge").
-            n_instances (int): The number of instances to deploy (default: 1).
-            recreate (bool): Whether to recreate the endpoint if it already exists (default: False).
-            role (Optional[str]): The IAM role ARN to associate with the model.
-            success_topic (Optional[str]): SNS topic ARN for successful inference notifications (default: None).
-            error_topic (Optional[str]): SNS topic ARN for error notifications (default: None).
-            wait (bool): Whether to wait for the endpoint to be fully deployed (default: True).
-            poll_interval (int): Interval in seconds to check the endpoint status (default: 30).
-            timeout (int): Maximum time in seconds to wait for the endpoint to be deployed (default: 3600).
+            arn: The model package ARN.
+            endpoint_name: The name of the endpoint.
+            s3_output_path: S3 path for asynchronous inference results.
+            instance_type: Instance type (e.g. ``ml.m5.xlarge``).
+            n_instances: Number of instances to deploy.
+            recreate: If ``True``, replace an existing endpoint with the same
+                name.
+            role: IAM role ARN for the model.
+            success_topic: SNS topic ARN for successful inference
+                notifications.
+            error_topic: SNS topic ARN for error notifications.
+            wait: Block until the endpoint reaches ``InService``.
+            poll_interval: Seconds between status polls when ``wait=True``.
+            timeout: Maximum seconds to wait for endpoint readiness.
+            model: Explicit model identifier passed through to
+                :meth:`connect_to_endpoint`.
         """
-        from botocore.exceptions import ClientError
-
         if role is None:
             role = get_role()
 
@@ -113,7 +234,6 @@ class Client:
         except ClientError:
             pass
 
-        # Create model
         self._sm_client.create_model(
             ModelName=model_name,
             ExecutionRoleArn=role,
@@ -121,24 +241,21 @@ class Client:
         )
         self._model_name = model_name
 
-        # Delete existing endpoint configuration if it exists
         try:
             self._sm_client.delete_endpoint_config(EndpointConfigName=endpoint_name)
         except ClientError:
             pass
 
-        # Check if the endpoint already exists
         if self._does_endpoint_exist(endpoint_name):
             if recreate:
-                self.connect_to_endpoint(endpoint_name, arn)
+                self.connect_to_endpoint(endpoint_name, arn, model=model)
                 self.delete_endpoint()
             else:
                 raise Exception(
                     f"Endpoint {endpoint_name} already exists and recreate={recreate}."
                 )
 
-        # Create an endpoint configuration with AsyncInferenceConfig
-        async_inference_config = {
+        async_inference_config: Dict = {
             "OutputConfig": {
                 "S3OutputPath": s3_output_path,
             }
@@ -173,7 +290,6 @@ class Client:
             EndpointConfigName=endpoint_name,
         )
 
-        # Wait for the endpoint to become "InService" if `wait` is True
         if wait:
             log.info(f"Waiting for endpoint {endpoint_name} to be InService...")
             start_time = time.time()
@@ -194,7 +310,7 @@ class Client:
                 log.info(f"Endpoint {endpoint_name} status: {status}. Waiting...")
                 time.sleep(poll_interval)
 
-        self.connect_to_endpoint(endpoint_name, arn)
+        self.connect_to_endpoint(endpoint_name, arn, model=model)
 
     def create_endpoint(
         self,
@@ -204,6 +320,8 @@ class Client:
         n_instances: int = 1,
         recreate: bool = False,
         role: Optional[str] = None,
+        *,
+        model: Optional[str] = None,
     ) -> None:
         import sagemaker
 
@@ -212,37 +330,32 @@ class Client:
 
         if self._does_endpoint_exist(endpoint_name):
             if recreate:
-                self.connect_to_endpoint(endpoint_name, arn)
+                self.connect_to_endpoint(endpoint_name, arn, model=model)
                 self.delete_endpoint()
             else:
                 raise Exception(
                     f"Endpoint {endpoint_name} already exists and recreate={recreate}."
                 )
 
-        # Check if there is already endpoint config, if so delete it or it will block model.deploy
         try:
             self._sm_client.delete_endpoint_config(EndpointConfigName=endpoint_name)
         except ClientError:
             pass
 
-        model = sagemaker.ModelPackage(
+        sm_model = sagemaker.ModelPackage(
             role=role,
             model_data=None,
-            sagemaker_session=self._sm_session,  # makes sure the right region is used
+            sagemaker_session=self._sm_session,
             model_package_arn=arn,
         )
 
         try:
-            model.deploy(
-                n_instances,
-                instance_type,
-                endpoint_name=endpoint_name,
-            )
+            sm_model.deploy(n_instances, instance_type, endpoint_name=endpoint_name)
         except ParamValidationError:
-            model.deploy(n_instances, instance_type, endpoint_name=endpoint_name)
+            sm_model.deploy(n_instances, instance_type, endpoint_name=endpoint_name)
 
         self._endpoint_config_name = endpoint_name
-        self.connect_to_endpoint(endpoint_name, arn)
+        self.connect_to_endpoint(endpoint_name, arn, model=model)
 
     def register_scalable_target(self, max_capacity, min_capacity=1):
         return self._aas_client.register_scalable_target(
@@ -269,7 +382,6 @@ class Client:
             {"Name": "VariantName", "Value": self._variant_name},
         ]
         kwargs["AlarmActions"] = [policy_arn]
-
         return self._cw_client.put_metric_alarm(**kwargs)
 
     def create_transform_job(
@@ -287,6 +399,18 @@ class Client:
     ) -> Optional[str]:
         import sagemaker
 
+        # wait=False kicks off the transform asynchronously and returns
+        # immediately; a local output_path triggers an immediate
+        # download_s3_folder which would land on empty/partial results.
+        # Refuse the combination up front instead of silently producing
+        # bad output.
+        if not wait and not output_path.startswith("s3://"):
+            raise ValueError(
+                "create_transform_job(wait=False) requires an s3:// "
+                "output_path. Use wait=True for a local output_path so the "
+                "transform completes before files are downloaded."
+            )
+
         if role is None:
             role = get_role()
 
@@ -294,12 +418,11 @@ class Client:
             name=arn.split("/")[-1],
             role=role,
             model_data=None,
-            sagemaker_session=self._sm_session,  # makes sure the right region is used
+            sagemaker_session=self._sm_session,
             model_package_arn=arn,
         )
 
         uid = uuid.uuid4().hex
-        # if input path is a local path, upload to default s3 bucket
         if not input_path.startswith("s3://"):
             if not os.path.exists(input_path):
                 raise FileNotFoundError(f"Input path {input_path} does not exist.")
@@ -313,8 +436,6 @@ class Client:
             log.info(f"Input file is already on S3, using {s3_input_path}.")
 
         download_output_path = None
-        # if output path is a local path, change to default s3 bucket,
-        # add job name and random uuid
         if not output_path.startswith("s3://"):
             download_output_path = output_path
             output_path = os.path.join(
@@ -354,74 +475,68 @@ class Client:
             job_name = transformer.latest_transform_job.name
         return job_name
 
-    def read_async(self, prompt: str, input_s3_path: str):
-        """
-        Asynchronous version of the read method that uses invoke_endpoint_async.
-
-        Args:
-            prompt (str): The input prompt for the model.
-            input_s3_path (str): S3 path where the input data will be uploaded.
-            output_s3_path (str): S3 path where the output data will be stored.
-
-        """
-        if self._endpoint_name is None:
+    def _require_endpoint(self) -> None:
+        if self._endpoint_name is None or self._model_spec is None:
             raise Exception("No endpoint connected. Run connect_to_endpoint() first.")
 
-        model = "reader-lm-0.5b"
-        if "1500m" in self._arn:
-            model = "reader-lm-1.5b"
-        elif "v2" in self._arn:
-            model = "ReaderLM-v2"
+    def _reader_model_name(self) -> str:
+        # Preserves pre-refactor behaviour: ARNs that didn't match the reader
+        # patterns silently defaulted to "reader-lm-0.5b" in the request body.
+        assert self._model_spec is not None  # _require_endpoint ran first
+        return self._model_spec.reader_model or "reader-lm-0.5b"
 
-        # Prepare the input payload
+    def read_async(self, prompt: str, input_s3_path: str):
+        """Asynchronous variant of :meth:`read` using ``invoke_endpoint_async``.
+
+        Args:
+            prompt: Input prompt for the ReaderLM model.
+            input_s3_path: S3 location where the input payload is uploaded
+                before the async invocation. Must be an ``s3://`` URI the
+                caller's credentials can write to.
+
+        Returns:
+            A dict with ``OutputLocation`` (the S3 URI of the async result)
+            and ``InputLocation`` (the URI passed in).
+        """
+        self._require_endpoint()
+
         data = json.dumps(
             {
-                "model": model,
+                "model": self._reader_model_name(),
                 "prompt": prompt,
             }
         )
 
-        s3 = boto3.client("s3")
+        # Reuse client_args so this s3 client honours the same region and
+        # credentials as the rest of the Client.
+        s3 = boto3.client("s3", **self._client_args)
         bucket_name, input_key = input_s3_path.replace("s3://", "").split("/", 1)
         s3.put_object(Bucket=bucket_name, Key=input_key, Body=data)
 
-        # Call the async endpoint
         response = self._sm_runtime_client.invoke_endpoint_async(
             EndpointName=self._endpoint_name,
             InputLocation=input_s3_path,
             ContentType="application/json",
         )
 
-        # Return the response metadata, including the output location
         return {
             "OutputLocation": response["OutputLocation"],
             "InputLocation": input_s3_path,
         }
 
     def read(self, prompt: str, stream: bool = False):
-        """
-        Send a request to a ReaderLM and process the response.
+        """Send a prompt to a ReaderLM endpoint and return the response.
 
         Args:
-            prompt (str): The input prompt for the model.
-            stream (bool, optional): Flag indicating whether the response should be
-                processed as a stream. Defaults to False.
-
+            prompt: Input prompt for the model.
+            stream: When ``True``, parse a server-sent-event style stream
+                and return the list of decoded events.
         """
-        if self._endpoint_name is None:
-            raise Exception(
-                "No endpoint connected. " "Run connect_to_endpoint() first."
-            )
-
-        model = "reader-lm-0.5b"
-        if "1500m" in self._arn:
-            model = "reader-lm-1.5b"
-        elif "v2" in self._arn:
-            model = "ReaderLM-v2"
+        self._require_endpoint()
 
         data = json.dumps(
             {
-                "model": model,
+                "model": self._reader_model_name(),
                 "prompt": prompt,
                 "stream": stream,
             }
@@ -440,7 +555,7 @@ class Client:
             for line in response_body.iter_lines():
                 if line:
                     decoded_line = line.decode("utf-8").strip()
-                    if decoded_line.startswith("data:"):  # Handle 'data:' prefix
+                    if decoded_line.startswith("data:"):
                         json_data = decoded_line[5:].strip()
                         try:
                             streamed_results.append(json.loads(json_data))
@@ -449,7 +564,6 @@ class Client:
 
             return streamed_results
         else:
-            # For non-streamed responses, read the entire body
             response_body = response["Body"].read().decode()
             return json.loads(response_body)
 
@@ -458,7 +572,7 @@ class Client:
         texts: Optional[Union[str, List[str]]] = None,
         image_urls: Optional[Union[str, List[str]]] = None,
         image_bytes: Optional[Union[str, List[str]]] = None,
-        pdf_url: Optional[str] = False,
+        pdf_url: Optional[str] = None,
         use_colbert: Optional[bool] = False,
         input_type: Optional[InputType] = InputType.DOCUMENT,
         task_type: Optional[Task] = None,
@@ -466,94 +580,79 @@ class Client:
         late_chunking: Optional[bool] = False,
         return_multivector: Optional[bool] = False,
     ):
+        """Embed text, images, or a PDF.
+
+        Args:
+            texts: The text or texts to embed.
+            image_urls: URL(s) of the image(s) to embed.
+            image_bytes: Base64-encoded image bytes.
+            pdf_url: URL of a PDF to embed. PDF cannot be mixed with other
+                media types and is only supported on ``jina-embeddings-v4``.
+            use_colbert: Use the ColBERT request shape.
+            input_type: Treat texts as queries or documents (ColBERT only).
+            task_type: Downstream task for v3/v4/clip-v2; ``None`` selects
+                the default ``"text-matching"``.
+            dimensions: Output dimensions (v3/v4/clip-v2).
+            late_chunking: Apply the late-chunking technique (v3/v4).
+            return_multivector: Return multi-vector output (v4 only).
         """
-        Embeds the given texts.
+        self._require_endpoint()
+        assert self._model_spec is not None  # _require_endpoint guarantees this
+        spec = self._model_spec
 
-        Parameters:
-            - texts (Union[str, List[str]]): The text or texts to embed. Can be a single
-            string or a list of strings.
-            - image_urls (Optional[Union[str, List[str]]]): URLs of the images to embed. Can be a single
-            URL or a list of URLs.
-            - image_bytes (Optional[Union[str, List[str]]]): Bytes of the images to embed. Can be a single
-            byte string or a list of byte strings.
-            - pdf_url (Optional[str]): URLs of the PDF to embed. PDF cannot be mixed with other media types.
-            - use_colbert (bool, optional): A flag indicating ColBERT model is used for embedding.
-            - input_type (InputType, optional): The type of input texts, indicating whether
-            they should be treated as documents or queries. This is only needed when use_colbert is True.
-            - task_type (Task, optional): Select the downstream task for which the
-            embeddings will be used. The model will return the optimized embeddings
-            for that task. None means no specific task is needed.
-            - dimensions (Optional[int], optional): Output dimensions. Smaller
-            dimensions are easier to store and retrieve, with minimal performance
-            impact thanks to MRL.
-            - late_chunking (Optional[bool], optional): Apply the late chunking
-            technique to leverage the model's long-context capabilities for
-            generating contextual chunk embeddings.
-            - return_multivector (Optional[bool], optional): Whether to return multi vector output.
-        """
+        if use_colbert:
+            if isinstance(texts, str):
+                payload = {
+                    "data": {"text": texts},
+                    "parameters": {"input_type": input_type.value},
+                }
+            else:
+                payload = {
+                    "data": [{"text": text} for text in texts],
+                    "parameters": {"input_type": input_type.value},
+                }
+            data = json.dumps(payload)
+        else:
+            data_obj: Dict = {"data": []}
 
-        if self._endpoint_name is None:
-            raise Exception(
-                "No endpoint connected. " "Run connect_to_endpoint() first."
-            )
-
-        if not use_colbert:
-            data = {"data": []}
-            if "jina-embeddings-v3" in self._arn or "jina-embeddings-v4" in self._arn:
-                data["parameters"] = {
+            if spec.family in ("embeddings-v3", "embeddings-v4"):
+                data_obj["parameters"] = {
                     "task": task_type.value if task_type else "text-matching",
                     "dimensions": dimensions,
                     "late_chunking": late_chunking,
                 }
-                if "jina-embeddings-v4" in self._arn:
-                    data["parameters"]["return_multivector"] = return_multivector
-            elif "jina-clip-v2" in self._arn:
-                data["parameters"] = {
+                if spec.family == "embeddings-v4":
+                    data_obj["parameters"]["return_multivector"] = return_multivector
+            elif spec.family == "clip-v2":
+                data_obj["parameters"] = {
                     "task": task_type.value if task_type else "text-matching",
                     "dimensions": dimensions,
                 }
 
             if texts:
                 if isinstance(texts, str):
-                    data["data"] += [{"text": texts}]
+                    data_obj["data"] += [{"text": texts}]
                 else:
-                    data["data"] += [{"text": text} for text in texts]
+                    data_obj["data"] += [{"text": text} for text in texts]
 
             if image_urls:
-                key = "url" if "jina-clip-v2" in self._arn else "image"
+                key = "url" if spec.family == "clip-v2" else "image"
                 if isinstance(image_urls, str):
-                    data["data"] += [{key: image_urls}]
+                    data_obj["data"] += [{key: image_urls}]
                 else:
-                    data["data"] += [{key: image_url} for image_url in image_urls]
+                    data_obj["data"] += [{key: image_url} for image_url in image_urls]
 
             if image_bytes:
-                key = "bytes" if "jina-clip-v2" in self._arn else "image"
+                key = "bytes" if spec.family == "clip-v2" else "image"
                 if isinstance(image_bytes, str):
-                    data["data"] += [{key: image_bytes}]
+                    data_obj["data"] += [{key: image_bytes}]
                 else:
-                    data["data"] += [
-                        {key: image_bytes_item} for image_bytes_item in image_bytes
-                    ]
+                    data_obj["data"] += [{key: ib} for ib in image_bytes]
 
-            if "jina-embeddings-v4" in self._arn and pdf_url:
-                data["data"] = {"pdf": pdf_url}
+            if spec.family == "embeddings-v4" and pdf_url:
+                data_obj["data"] = {"pdf": pdf_url}
 
-            data = json.dumps(data)
-        else:
-            if isinstance(texts, str):
-                data = json.dumps(
-                    {
-                        "data": {"text": texts},
-                        "parameters": {"input_type": input_type.value},
-                    }
-                )
-            else:
-                data = json.dumps(
-                    {
-                        "data": [{"text": text} for text in texts],
-                        "parameters": {"input_type": input_type.value},
-                    }
-                )
+            data = json.dumps(data_obj)
 
         response = self._sm_runtime_client.invoke_endpoint(
             EndpointName=self._endpoint_name,
@@ -565,12 +664,14 @@ class Client:
         return resp["data"]
 
     def rerank(
-        self, documents: List[Union[str, dict]], query: str, top_n: Optional[int] = None
+        self,
+        documents: List[Union[str, dict]],
+        query: str,
+        top_n: Optional[int] = None,
     ):
-        if self._endpoint_name is None:
-            raise Exception("No endpoint connected. Run connect_to_endpoint() first.")
+        self._require_endpoint()
+        assert self._model_spec is not None
 
-        # Normalize input into list of dicts
         normalized_documents = []
         for doc in documents:
             if isinstance(doc, str):
@@ -580,7 +681,7 @@ class Client:
             else:
                 raise ValueError(f"Unsupported document type: {type(doc)}")
 
-        data = {
+        data: Dict = {
             "documents": normalized_documents,
             "query": query,
         }
@@ -588,7 +689,7 @@ class Client:
         if top_n:
             data["top_n"] = min(top_n, len(normalized_documents))
 
-        if "jina-reranker-m0" in self._arn:
+        if self._model_spec.family == "reranker-m0":
             payload = json.dumps({"data": [data]})
         else:
             payload = json.dumps({"data": data})
@@ -603,21 +704,16 @@ class Client:
         return resp["data"]
 
     def delete_endpoint(self) -> None:
-        """
-        Deletes the endpoint, its configuration, and the associated model if their names are set.
-        """
-
+        """Delete the endpoint, its config, and the model (if set)."""
         if self._endpoint_name is None:
             raise Exception("No endpoint connected.")
 
-        # Delete the endpoint
         try:
             self._sm_client.delete_endpoint(EndpointName=self._endpoint_name)
             log.info(f"Deleted endpoint: {self._endpoint_name}")
         except ClientError:
             log.info(f"Endpoint '{self._endpoint_name}' not found, skipping deletion.")
 
-        # Delete the endpoint configuration
         if self._endpoint_config_name is not None:
             try:
                 self._sm_client.delete_endpoint_config(
@@ -628,10 +724,10 @@ class Client:
                 )
             except ClientError:
                 log.info(
-                    f"Endpoint configuration '{self._endpoint_config_name}' not found, skipping deletion."
+                    f"Endpoint configuration '{self._endpoint_config_name}' "
+                    "not found, skipping deletion."
                 )
 
-        # Delete the model
         if self._model_name is not None:
             try:
                 self._sm_client.delete_model(ModelName=self._model_name)
@@ -640,12 +736,19 @@ class Client:
                 log.info(f"Model '{self._model_name}' not found, skipping deletion.")
 
     def close(self) -> None:
+        """Close the underlying boto3 clients.
+
+        Older boto3 releases (pre-1.27) did not implement ``.close()`` on the
+        low-level clients; in that case we log a single info line and
+        continue rather than raising AttributeError, since this is a
+        best-effort cleanup.
+        """
         try:
             self._sm_runtime_client.close()
             self._sm_client.close()
         except AttributeError:
             log.info(
-                "SageMaker client could not be closed. "
-                "This might be because you are using an old version of SageMaker."
+                "SageMaker client could not be closed; this can happen on "
+                "very old boto3 versions where Client.close() was not yet "
+                "implemented. Continuing."
             )
-            raise

--- a/jina_sagemaker/helper.py
+++ b/jina_sagemaker/helper.py
@@ -27,7 +27,10 @@ def prefix_csv_with_ids(input_path: str) -> str:
         if first_row is None:
             raise ValueError(f"Input CSV {input_path!r} is empty")
 
-        has_uuid = is_uuid(first_row[0])
+        # csv.reader returns an empty list ([]) for a blank leading line —
+        # treat that as "no UUID present" so we still prefix every data row
+        # rather than crashing on first_row[0].
+        has_uuid = is_uuid(first_row[0]) if first_row else False
 
         infile.seek(0)
         for row in reader:

--- a/jina_sagemaker/helper.py
+++ b/jina_sagemaker/helper.py
@@ -25,9 +25,9 @@ def prefix_csv_with_ids(input_path: str) -> str:
 
         first_row = next(reader, None)
         if first_row is None:
-            return
+            raise ValueError(f"Input CSV {input_path!r} is empty")
 
-        has_uuid = is_uuid(first_row[0]) if first_row else False
+        has_uuid = is_uuid(first_row[0])
 
         infile.seek(0)
         for row in reader:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,10 +57,13 @@ def _json_streaming(obj) -> StreamingBody:
 def _connect(client: Client, arn: str, endpoint_name: str = "test-endpoint") -> None:
     """Bypass connect_to_endpoint() so individual tests don't have to stub
     describe_endpoint just to set up Client state."""
+    from jina_sagemaker.client import _resolve_model
+
     client._endpoint_name = endpoint_name
     client._variant_name = "AllTraffic"
     client._resource_id = f"endpoint/{endpoint_name}/variant/AllTraffic"
     client._arn = arn
+    client._model_spec = _resolve_model(arn)
 
 
 def _describe_endpoint_response(name: str = "test-endpoint") -> dict:
@@ -691,7 +694,7 @@ def test_read_async_model_dispatch(client, arn, model_name):
 
         result = client.read_async("hi", input_s3)
 
-    boto_client.assert_called_once_with("s3")
+    boto_client.assert_called_once_with("s3", region_name="us-east-1")
     s3_mock.put_object.assert_called_once_with(
         Bucket="bucket", Key="prefix/input.json", Body=expected_body
     )
@@ -731,3 +734,112 @@ def test_delete_endpoint_only_endpoint_set(client):
     with Stubber(client._sm_client) as stub:
         stub.add_response("delete_endpoint", {}, {"EndpointName": "test-endpoint"})
         client.delete_endpoint()
+
+
+# ----------------------------------------------------------------------------
+# PR2 hardening: model dispatch override, region threading, close(),
+# create_transform_job wait=False guard.
+# ----------------------------------------------------------------------------
+
+
+def test_resolve_model_detects_each_family():
+    from jina_sagemaker.client import _resolve_model
+
+    cases = [
+        (ARN_V2, "embeddings-default"),
+        (ARN_V3, "embeddings-v3"),
+        (ARN_V4, "embeddings-v4"),
+        (ARN_CLIP_V2, "clip-v2"),
+        (ARN_RERANKER, "reranker"),
+        (ARN_RERANKER_M0, "reranker-m0"),
+        (ARN_READER_0_5B, "reader-lm"),
+        (ARN_READER_1_5B, "reader-lm"),
+        (ARN_READER_LM_V2, "reader-lm"),
+        (ARN_COLBERT, "colbert"),
+    ]
+    for arn, family in cases:
+        assert _resolve_model(arn).family == family, arn
+
+
+def test_resolve_model_override_wins_over_arn():
+    from jina_sagemaker.client import _resolve_model
+
+    # ARN points at clip-v2 but the customer claims it's actually a v4 endpoint.
+    spec = _resolve_model(ARN_CLIP_V2, override="jina-embeddings-v4")
+    assert spec.family == "embeddings-v4"
+
+
+def test_resolve_model_unknown_override_raises():
+    from jina_sagemaker.client import _resolve_model
+
+    with pytest.raises(ValueError, match="Unknown model override"):
+        _resolve_model(ARN_V3, override="jina-embeddings-v999")
+
+
+def test_connect_to_endpoint_with_model_override(client):
+    with Stubber(client._sm_client) as stub:
+        stub.add_response(
+            "describe_endpoint",
+            _describe_endpoint_response("test-endpoint"),
+            {"EndpointName": "test-endpoint"},
+        )
+        client.connect_to_endpoint(
+            "test-endpoint", ARN_CLIP_V2, model="jina-embeddings-v4"
+        )
+    assert client._model_spec is not None
+    assert client._model_spec.family == "embeddings-v4"
+
+
+def test_init_threads_region_into_sagemaker_session(monkeypatch):
+    """The high-level sagemaker SDK must honour Client(region_name=...) too."""
+    captured = {}
+
+    def fake_session(*args, **kwargs):
+        captured["region_name"] = kwargs.get("region_name")
+        return mock.MagicMock()
+
+    monkeypatch.setattr("jina_sagemaker.client.boto3.Session", fake_session)
+    Client(region_name="eu-west-1")
+    assert captured["region_name"] == "eu-west-1"
+
+
+def test_init_stores_client_args_for_reuse():
+    c = Client(region_name="ap-northeast-1")
+    assert c._client_args["region_name"] == "ap-northeast-1"
+
+
+def test_close_suppresses_attribute_error_on_old_boto3(client, caplog):
+    """Older boto3 builds lacked client.close(); we must not re-raise."""
+    import logging as _logging
+
+    client._sm_runtime_client.close = mock.MagicMock(
+        side_effect=AttributeError("'BotocoreClient' object has no attribute 'close'")
+    )
+    with caplog.at_level(_logging.INFO, logger="jina_sagemaker.client"):
+        client.close()  # must not raise
+
+    assert any("could not be closed" in rec.message for rec in caplog.records)
+
+
+def test_close_succeeds_on_modern_boto3(client):
+    runtime_close = mock.MagicMock()
+    sm_close = mock.MagicMock()
+    client._sm_runtime_client.close = runtime_close
+    client._sm_client.close = sm_close
+
+    client.close()
+
+    runtime_close.assert_called_once_with()
+    sm_close.assert_called_once_with()
+
+
+def test_create_transform_job_rejects_wait_false_with_local_output(client):
+    with pytest.raises(ValueError, match="requires an s3:// output_path"):
+        client.create_transform_job(
+            arn=ARN_V3,
+            n_instances=1,
+            instance_type="ml.m5.xlarge",
+            input_path="s3://bucket/in.csv",
+            output_path="/tmp/local-output",
+            wait=False,
+        )

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -58,6 +58,30 @@ def test_prefix_csv_raises_on_empty_input():
         os.remove(input_path)
 
 
+def test_prefix_csv_handles_blank_leading_line():
+    """A CSV whose first line is blank must NOT crash on first_row[0]."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", delete=False, suffix=".csv", encoding="utf-8"
+    ) as f:
+        f.write("\nHow is the weather today?\nWhen are you open?\n")
+        input_path = f.name
+
+    try:
+        output_path = prefix_csv_with_ids(input_path)
+        rows = _read_rows(output_path)
+
+        # The blank leading line is dropped by csv.reader; every remaining
+        # row gets a fresh UUID prefix.
+        assert len(rows) >= 2
+        for row in rows:
+            if row:  # ignore any blank rows the reader emits
+                uuid.UUID(row[0])
+    finally:
+        os.remove(input_path)
+        if "output_path" in dir() and os.path.exists(output_path):
+            os.remove(output_path)
+
+
 def test_prefix_csv_preserves_existing_uuids():
     with tempfile.NamedTemporaryFile(
         mode="w", delete=False, suffix=".csv", encoding="utf-8"

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -3,6 +3,8 @@ import os
 import tempfile
 import uuid
 
+import pytest
+
 from jina_sagemaker.helper import prefix_csv_with_ids
 
 # Real 32-character hex UUIDs (no dashes) — uuid.UUID() accepts both forms.
@@ -40,6 +42,20 @@ def test_prefix_csv_adds_uuid_when_missing():
         os.remove(input_path)
         if os.path.exists(output_path):
             os.remove(output_path)
+
+
+def test_prefix_csv_raises_on_empty_input():
+    with tempfile.NamedTemporaryFile(
+        mode="w", delete=False, suffix=".csv", encoding="utf-8"
+    ) as f:
+        input_path = f.name
+        # leave file empty
+
+    try:
+        with pytest.raises(ValueError, match="empty"):
+            prefix_csv_with_ids(input_path)
+    finally:
+        os.remove(input_path)
 
 
 def test_prefix_csv_preserves_existing_uuids():


### PR DESCRIPTION
> Stacked on top of #58. Base will retarget to \`main\` once #58 merges.

## Context

The Client currently determines model behaviour by substring-matching the ARN at every callsite: \`embed()\`, \`rerank()\`, \`read()\`, and \`read_async()\` each call \`"x" in self._arn\` to decide payload shape, with the ReaderLM detection logic copy-pasted between \`read()\` and \`read_async()\`. It also calls \`logging.basicConfig()\` on module import (silently hijacking consuming applications' root logger), ignores \`Client(region_name=...)\` for the sagemaker SDK Session and for the ad-hoc S3 client used in \`read_async\`, and has a footgun in \`create_transform_job\` where \`wait=False\` + local \`output_path\` silently produces an empty download.

This PR is the behavioural half of the modernization started in #58. #58 set up the regression net (the Stubber-based test suite that locks the wire payloads); this PR can refactor model dispatch with confidence that the request bodies emitted by every method stay byte-for-byte identical.

## Description

Centralise model dispatch through a single \`_resolve_model(arn, override=None) -> ModelSpec\` function, with a keyword-only \`model=\` escape hatch on \`connect_to_endpoint()\` for customers whose ARN does not match the detection table. Thread \`region_name\` through every AWS client the \`Client\` constructs. Remove the \`logging.basicConfig\` call. Fix the \`close()\` and \`prefix_csv_with_ids\` bugs called out in the original audit. Reject \`create_transform_job(wait=False, output_path=<local>)\` up front.

## Changes in the Codebase

**\`jina_sagemaker/client.py\`**

- New \`ModelSpec\` dataclass (frozen) and \`_resolve_model(arn, override=None)\` function.
- New \`_DETECTION_TABLE\` (list of \`(slug, ModelSpec)\` tuples, most-specific first) and \`_OVERRIDE_TABLE\` (canonical-name lookup for the \`model=\` override).
- \`Client.__init__\`:
  - Stores \`self._client_args\` so methods that build their own boto3 clients (\`read_async\`) reuse the same region + credentials.
  - Passes \`region_name=client_args.get("region_name")\` to \`boto3.Session(...)\` so the sagemaker SDK honours \`Client(region_name=...)\`.
  - Initialises \`_arn\`, \`_model_spec\`, \`_variant_name\`, \`_resource_id\` to \`None\` so methods called before \`connect_to_endpoint()\` raise the explicit "No endpoint connected" message instead of \`AttributeError\`.
- \`connect_to_endpoint(name, arn, *, model=None)\`, \`create_endpoint(... *, model=None)\`, \`create_async_endpoint(..., *, model=None)\`: new keyword-only \`model=\` argument that bypasses ARN detection. Unknown override values raise \`ValueError\` immediately.
- \`embed()\`, \`rerank()\`, \`read()\`, \`read_async()\` now read \`self._model_spec.family\` / \`.reader_model\` instead of substring-matching \`self._arn\`. The duplicated reader-lm dispatch in \`read()\` and \`read_async()\` is consolidated into \`_reader_model_name()\`.
- New \`_require_endpoint()\` helper centralises the "No endpoint connected" check used by every inference method.
- \`read_async()\` builds its S3 client via \`boto3.client("s3", **self._client_args)\` instead of a bare \`boto3.client("s3")\`.
- \`create_transform_job()\` raises \`ValueError\` at the top of the method when \`wait=False\` is combined with a non-\`s3://\` \`output_path\` — previously the code would happily call \`download_s3_folder\` on an empty bucket immediately after kicking off the async transform.
- \`close()\` logs and continues on \`AttributeError\` (for ancient boto3 versions that did not implement \`Client.close()\`); previously it logged "this is fine" and then re-raised, contradicting its own message.
- \`pdf_url\` parameter default changed from \`False\` to \`None\` to match its \`Optional[str]\` annotation.
- \`read_async()\` docstring no longer references an \`output_s3_path\` argument that does not exist in the signature.
- Drops the redundant inline \`from botocore.exceptions import ClientError\` inside \`create_async_endpoint()\`; it is already imported at module top.
- Removes \`logging.basicConfig(level=logging.INFO)\` from the top of the module.

**\`jina_sagemaker/helper.py\`**

- \`prefix_csv_with_ids()\` now raises \`ValueError\` on empty input instead of silently returning \`None\` to a caller that expects a path string.

**Tests** (\`tests/test_client.py\`, \`tests/test_helper.py\`)

- 10 new tests covering: every detection-table entry produces the right \`family\`; \`model=\` override wins over ARN; unknown override raises \`ValueError\`; \`connect_to_endpoint(..., model=...)\` is honoured; \`Client(region_name=...)\` is threaded into \`boto3.Session\`; \`_client_args\` is stored; \`close()\` suppresses \`AttributeError\` on old boto3 and succeeds on modern boto3; \`create_transform_job(wait=False, local_path)\` raises; \`prefix_csv_with_ids\` on empty input raises.
- Updated \`test_read_async_model_dispatch\` for the new \`boto3.client("s3", region_name=...)\` call shape.
- Updated \`_connect\` helper to also set \`_model_spec\` (required by the new \`_require_endpoint\` check).
- Test count: 50 (was 40 in #58).

## Changes Outside the Codebase

None.

## Testing

- \`pytest -v\` → 50 passed locally on Python 3.14.3 with sagemaker 2.257.3.
- \`black --check .\`, \`isort --check .\`, \`flake8\` (syntax + style + complexity ≤ 20) all clean.
- Every existing #58 test still passes after the refactor — verifies the dispatch refactor is byte-for-byte payload-equivalent to the pre-refactor code for all 10 ARN fixtures.

## Additional Information

**Non-breaking on the call sites that already work**

- \`connect_to_endpoint(name, arn)\` still works. The new \`model=\` argument is keyword-only and defaults to \`None\` (= run detection, same as today).
- Every model family currently supported (v2 / v3 / v4 / clip-v2 / colbert / reranker / reranker-m0 / reader-lm 0.5b / 1.5b / v2) keeps producing the exact same request body — verified by 38 Stubber-pinned regression tests from #58.

**Edge-cases handled differently**

- \`close()\` on old boto3: previously re-raised \`AttributeError\` after logging. Now logs and continues (cleanup is idempotent; re-raising helped no caller).
- \`prefix_csv_with_ids(empty.csv)\`: previously returned \`None\` and let the caller blow up two lines later in \`upload_data(path=None)\`. Now raises \`ValueError\` immediately with a clear message.
- \`create_transform_job(wait=False, output_path="/tmp/out")\`: previously produced an empty local directory with no error. Now raises \`ValueError\` at the top of the method.
- Unknown ARN in \`embed()\` / \`rerank()\`: falls back to \`embeddings-default\` (no \`parameters\` block) — same behaviour as before.
- Unknown ARN in \`read()\` / \`read_async()\`: falls back to \`reader-lm-0.5b\` as the model name in the request body — same behaviour as before.

**For the next new Jina SageMaker model**

Add one entry to \`_DETECTION_TABLE\` and \`_OVERRIDE_TABLE\` is automatically populated from it. The most-specific slugs come first so collision risk is bounded.