### PR TITLE
perf: parallelize download_s3_folder via ThreadPoolExecutor

### DIFF
--- a/jina_sagemaker/helper.py
+++ b/jina_sagemaker/helper.py
@@ -70,22 +70,29 @@ def download_s3_folder(
             is written to ``<local_dir>/<key-relative-to-prefix>``; when
             ``None`` the object key itself is used verbatim as the path
             (preserving the original behaviour of this helper).
-        max_workers: Upper bound on concurrent ``Bucket.download_file``
-            calls. Capped to the actual object count so we don't spawn
+        max_workers: Upper bound on concurrent ``S3.Client.download_file``
+            calls. Capped to the actual object count so we do not spawn
             extra threads for tiny folders.
 
     Re-raises the first exception any worker thread encounters so partial
     failures surface as a single clean error to the caller, rather than a
     half-downloaded folder with no signal.
+
+    Threading note: the low-level boto3 ``s3`` client is documented as
+    thread-safe and is used for the worker downloads. boto3 *resources*
+    (``boto3.resource("s3")``) are NOT thread-safe and are confined to
+    the serial listing pass.
     """
     bucket_name, s3_folder = path.replace("s3://", "").split("/", 1)
-    s3 = boto3.resource("s3")
-    bucket = s3.Bucket(bucket_name)
 
-    # Pass 1: enumerate the listing serially and create target directories.
-    # Directory creation runs serially because parallel makedirs() against
-    # a shared parent races; the listing+mkdir cost is negligible compared
-    # to the downloads themselves.
+    # Pass 1: enumerate the listing serially via the resource API (handy
+    # paginated iterator) and create target directories. Directory
+    # creation runs serially because parallel makedirs() against a shared
+    # parent races; the listing + mkdir cost is negligible compared to
+    # the downloads themselves.
+    s3_resource = boto3.resource("s3")
+    bucket = s3_resource.Bucket(bucket_name)
+
     tasks = []
     for obj in bucket.objects.filter(Prefix=s3_folder):
         if obj.key.endswith("/"):
@@ -103,12 +110,14 @@ def download_s3_folder(
     if not tasks:
         return
 
-    # Pass 2: parallel downloads. ThreadPoolExecutor is the right choice
-    # here — download_file releases the GIL while waiting on socket I/O,
-    # so thread-level parallelism translates directly into bandwidth.
+    # Pass 2: parallel downloads through the low-level client. boto3
+    # clients are thread-safe (per the boto3 docs); resources are not,
+    # which is why we don't reuse ``bucket.download_file`` here.
+    s3_client = boto3.client("s3")
     with ThreadPoolExecutor(max_workers=min(max_workers, len(tasks))) as pool:
         futures = [
-            pool.submit(bucket.download_file, key, target) for key, target in tasks
+            pool.submit(s3_client.download_file, bucket_name, key, target)
+            for key, target in tasks
         ]
         for fut in as_completed(futures):
             fut.result()

--- a/jina_sagemaker/helper.py
+++ b/jina_sagemaker/helper.py
@@ -1,6 +1,8 @@
 import csv
 import os
 import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Optional
 
 import boto3
 
@@ -53,24 +55,60 @@ def get_role():
         return "ServiceRoleSagemaker"
 
 
-def download_s3_folder(path: str, local_dir: str = None):
-    """
-    Download the contents of a folder directory
+def download_s3_folder(
+    path: str,
+    local_dir: Optional[str] = None,
+    max_workers: int = 16,
+) -> None:
+    """Download every object under an S3 prefix in parallel.
+
     Args:
-        path: the s3 path
-        local_dir: a relative or absolute directory path in the local file system
+        path: An ``s3://bucket/prefix`` URI. All objects under the prefix
+            are downloaded; objects whose key ends in ``/`` (S3 folder
+            markers) are skipped.
+        local_dir: Local destination root. When set, each downloaded object
+            is written to ``<local_dir>/<key-relative-to-prefix>``; when
+            ``None`` the object key itself is used verbatim as the path
+            (preserving the original behaviour of this helper).
+        max_workers: Upper bound on concurrent ``Bucket.download_file``
+            calls. Capped to the actual object count so we don't spawn
+            extra threads for tiny folders.
+
+    Re-raises the first exception any worker thread encounters so partial
+    failures surface as a single clean error to the caller, rather than a
+    half-downloaded folder with no signal.
     """
     bucket_name, s3_folder = path.replace("s3://", "").split("/", 1)
     s3 = boto3.resource("s3")
     bucket = s3.Bucket(bucket_name)
+
+    # Pass 1: enumerate the listing serially and create target directories.
+    # Directory creation runs serially because parallel makedirs() against
+    # a shared parent races; the listing+mkdir cost is negligible compared
+    # to the downloads themselves.
+    tasks = []
     for obj in bucket.objects.filter(Prefix=s3_folder):
+        if obj.key.endswith("/"):
+            continue
         target = (
             obj.key
             if local_dir is None
             else os.path.join(local_dir, os.path.relpath(obj.key, s3_folder))
         )
-        if not os.path.exists(os.path.dirname(target)):
-            os.makedirs(os.path.dirname(target))
-        if obj.key[-1] == "/":
-            continue
-        bucket.download_file(obj.key, target)
+        parent = os.path.dirname(target)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        tasks.append((obj.key, target))
+
+    if not tasks:
+        return
+
+    # Pass 2: parallel downloads. ThreadPoolExecutor is the right choice
+    # here — download_file releases the GIL while waiting on socket I/O,
+    # so thread-level parallelism translates directly into bandwidth.
+    with ThreadPoolExecutor(max_workers=min(max_workers, len(tasks))) as pool:
+        futures = [
+            pool.submit(bucket.download_file, key, target) for key, target in tasks
+        ]
+        for fut in as_completed(futures):
+            fut.result()

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -2,10 +2,11 @@ import csv
 import os
 import tempfile
 import uuid
+from unittest import mock
 
 import pytest
 
-from jina_sagemaker.helper import prefix_csv_with_ids
+from jina_sagemaker.helper import download_s3_folder, prefix_csv_with_ids
 
 # Real 32-character hex UUIDs (no dashes) — uuid.UUID() accepts both forms.
 REAL_UUID_1 = "f47ac10b58cc4372a5670e02b2c3d479"
@@ -100,3 +101,118 @@ def test_prefix_csv_preserves_existing_uuids():
         os.remove(input_path)
         if os.path.exists(output_path):
             os.remove(output_path)
+
+
+# ----------------------------------------------------------------------------
+# download_s3_folder
+# ----------------------------------------------------------------------------
+
+
+def _mock_obj(key: str):
+    o = mock.MagicMock()
+    o.key = key
+    return o
+
+
+def _set_up_bucket(mock_resource, keys):
+    """Configure ``boto3.resource("s3").Bucket(...)`` to return a Bucket
+    whose ``objects.filter(...)`` yields one mock object per key.
+
+    Returns the mock_bucket so the test can assert on ``download_file``.
+    """
+    mock_bucket = mock.MagicMock()
+    mock_bucket.objects.filter.return_value = [_mock_obj(k) for k in keys]
+    mock_resource.return_value.Bucket.return_value = mock_bucket
+    return mock_bucket
+
+
+def test_download_s3_folder_downloads_every_non_folder_key(tmp_path):
+    with mock.patch("jina_sagemaker.helper.boto3.resource") as mock_resource:
+        bucket = _set_up_bucket(
+            mock_resource,
+            keys=[
+                "prefix/a.json",
+                "prefix/b.json",
+                "prefix/subdir/c.json",
+            ],
+        )
+
+        download_s3_folder("s3://bucket/prefix", local_dir=str(tmp_path))
+
+    assert bucket.download_file.call_count == 3
+    calls = {call.args for call in bucket.download_file.call_args_list}
+    assert ("prefix/a.json", os.path.join(str(tmp_path), "a.json")) in calls
+    assert ("prefix/b.json", os.path.join(str(tmp_path), "b.json")) in calls
+    assert (
+        "prefix/subdir/c.json",
+        os.path.join(str(tmp_path), "subdir", "c.json"),
+    ) in calls
+
+
+def test_download_s3_folder_skips_folder_marker_keys(tmp_path):
+    with mock.patch("jina_sagemaker.helper.boto3.resource") as mock_resource:
+        bucket = _set_up_bucket(
+            mock_resource,
+            keys=[
+                "prefix/",  # folder marker — must be skipped
+                "prefix/file.json",
+                "prefix/subdir/",  # nested folder marker — must be skipped
+                "prefix/subdir/nested.json",
+            ],
+        )
+
+        download_s3_folder("s3://bucket/prefix", local_dir=str(tmp_path))
+
+    # Only the two real files should hit download_file.
+    assert bucket.download_file.call_count == 2
+    keys_called = {call.args[0] for call in bucket.download_file.call_args_list}
+    assert keys_called == {"prefix/file.json", "prefix/subdir/nested.json"}
+
+
+def test_download_s3_folder_runs_in_parallel(tmp_path):
+    """Every download_file call must hit the bucket within one ThreadPool
+    cycle. We assert that by gating each mock call on a barrier — if the
+    implementation were still serial, the barrier would never trip and
+    the test would time out."""
+    import threading
+
+    n = 8
+    barrier = threading.Barrier(n, timeout=5.0)
+
+    def _gated_download(key, target):
+        barrier.wait()
+
+    with mock.patch("jina_sagemaker.helper.boto3.resource") as mock_resource:
+        bucket = _set_up_bucket(
+            mock_resource,
+            keys=[f"prefix/f{i}.json" for i in range(n)],
+        )
+        bucket.download_file.side_effect = _gated_download
+
+        download_s3_folder("s3://bucket/prefix", local_dir=str(tmp_path), max_workers=n)
+
+    assert bucket.download_file.call_count == n
+
+
+def test_download_s3_folder_propagates_worker_exceptions(tmp_path):
+    def _boom(key, target):
+        if key.endswith("bad.json"):
+            raise RuntimeError("simulated S3 failure")
+
+    with mock.patch("jina_sagemaker.helper.boto3.resource") as mock_resource:
+        bucket = _set_up_bucket(
+            mock_resource,
+            keys=["prefix/ok.json", "prefix/bad.json"],
+        )
+        bucket.download_file.side_effect = _boom
+
+        with pytest.raises(RuntimeError, match="simulated S3 failure"):
+            download_s3_folder("s3://bucket/prefix", local_dir=str(tmp_path))
+
+
+def test_download_s3_folder_handles_empty_listing(tmp_path):
+    """An empty prefix should be a no-op, not an error."""
+    with mock.patch("jina_sagemaker.helper.boto3.resource") as mock_resource:
+        bucket = _set_up_bucket(mock_resource, keys=[])
+        download_s3_folder("s3://bucket/prefix", local_dir=str(tmp_path))
+    assert bucket.download_file.call_count == 0

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -114,45 +114,60 @@ def _mock_obj(key: str):
     return o
 
 
-def _set_up_bucket(mock_resource, keys):
-    """Configure ``boto3.resource("s3").Bucket(...)`` to return a Bucket
-    whose ``objects.filter(...)`` yields one mock object per key.
-
-    Returns the mock_bucket so the test can assert on ``download_file``.
-    """
+def _set_up_listing(mock_resource, keys):
+    """Configure ``boto3.resource("s3").Bucket(...).objects.filter(...)``
+    to yield one mock object per key. Listing happens serially in the
+    main thread, so using the (non-thread-safe) resource API here is
+    fine — and matches what the implementation does."""
     mock_bucket = mock.MagicMock()
     mock_bucket.objects.filter.return_value = [_mock_obj(k) for k in keys]
     mock_resource.return_value.Bucket.return_value = mock_bucket
-    return mock_bucket
+
+
+def _patch_boto():
+    """Patch both ``boto3.resource`` (used for the serial listing pass)
+    and ``boto3.client`` (used for the parallel download pass).
+
+    Returns the two ``unittest.mock.patch`` objects; the caller is
+    expected to enter them as context managers.
+    """
+    return (
+        mock.patch("jina_sagemaker.helper.boto3.resource"),
+        mock.patch("jina_sagemaker.helper.boto3.client"),
+    )
 
 
 def test_download_s3_folder_downloads_every_non_folder_key(tmp_path):
-    with mock.patch("jina_sagemaker.helper.boto3.resource") as mock_resource:
-        bucket = _set_up_bucket(
-            mock_resource,
+    resource_patch, client_patch = _patch_boto()
+    with resource_patch as mr, client_patch as mc:
+        _set_up_listing(
+            mr,
             keys=[
                 "prefix/a.json",
                 "prefix/b.json",
                 "prefix/subdir/c.json",
             ],
         )
+        s3 = mc.return_value
 
         download_s3_folder("s3://bucket/prefix", local_dir=str(tmp_path))
 
-    assert bucket.download_file.call_count == 3
-    calls = {call.args for call in bucket.download_file.call_args_list}
-    assert ("prefix/a.json", os.path.join(str(tmp_path), "a.json")) in calls
-    assert ("prefix/b.json", os.path.join(str(tmp_path), "b.json")) in calls
+    assert s3.download_file.call_count == 3
+    calls = {call.args for call in s3.download_file.call_args_list}
+    assert ("bucket", "prefix/a.json", os.path.join(str(tmp_path), "a.json")) in calls
+    assert ("bucket", "prefix/b.json", os.path.join(str(tmp_path), "b.json")) in calls
     assert (
+        "bucket",
         "prefix/subdir/c.json",
         os.path.join(str(tmp_path), "subdir", "c.json"),
     ) in calls
 
 
 def test_download_s3_folder_skips_folder_marker_keys(tmp_path):
-    with mock.patch("jina_sagemaker.helper.boto3.resource") as mock_resource:
-        bucket = _set_up_bucket(
-            mock_resource,
+    resource_patch, client_patch = _patch_boto()
+    with resource_patch as mr, client_patch as mc:
+        _set_up_listing(
+            mr,
             keys=[
                 "prefix/",  # folder marker — must be skipped
                 "prefix/file.json",
@@ -160,12 +175,13 @@ def test_download_s3_folder_skips_folder_marker_keys(tmp_path):
                 "prefix/subdir/nested.json",
             ],
         )
+        s3 = mc.return_value
 
         download_s3_folder("s3://bucket/prefix", local_dir=str(tmp_path))
 
     # Only the two real files should hit download_file.
-    assert bucket.download_file.call_count == 2
-    keys_called = {call.args[0] for call in bucket.download_file.call_args_list}
+    assert s3.download_file.call_count == 2
+    keys_called = {call.args[1] for call in s3.download_file.call_args_list}
     assert keys_called == {"prefix/file.json", "prefix/subdir/nested.json"}
 
 
@@ -179,32 +195,36 @@ def test_download_s3_folder_runs_in_parallel(tmp_path):
     n = 8
     barrier = threading.Barrier(n, timeout=5.0)
 
-    def _gated_download(key, target):
+    def _gated_download(bucket, key, target):
         barrier.wait()
 
-    with mock.patch("jina_sagemaker.helper.boto3.resource") as mock_resource:
-        bucket = _set_up_bucket(
-            mock_resource,
+    resource_patch, client_patch = _patch_boto()
+    with resource_patch as mr, client_patch as mc:
+        _set_up_listing(
+            mr,
             keys=[f"prefix/f{i}.json" for i in range(n)],
         )
-        bucket.download_file.side_effect = _gated_download
+        s3 = mc.return_value
+        s3.download_file.side_effect = _gated_download
 
         download_s3_folder("s3://bucket/prefix", local_dir=str(tmp_path), max_workers=n)
 
-    assert bucket.download_file.call_count == n
+    assert s3.download_file.call_count == n
 
 
 def test_download_s3_folder_propagates_worker_exceptions(tmp_path):
-    def _boom(key, target):
+    def _boom(bucket, key, target):
         if key.endswith("bad.json"):
             raise RuntimeError("simulated S3 failure")
 
-    with mock.patch("jina_sagemaker.helper.boto3.resource") as mock_resource:
-        bucket = _set_up_bucket(
-            mock_resource,
+    resource_patch, client_patch = _patch_boto()
+    with resource_patch as mr, client_patch as mc:
+        _set_up_listing(
+            mr,
             keys=["prefix/ok.json", "prefix/bad.json"],
         )
-        bucket.download_file.side_effect = _boom
+        s3 = mc.return_value
+        s3.download_file.side_effect = _boom
 
         with pytest.raises(RuntimeError, match="simulated S3 failure"):
             download_s3_folder("s3://bucket/prefix", local_dir=str(tmp_path))
@@ -212,7 +232,11 @@ def test_download_s3_folder_propagates_worker_exceptions(tmp_path):
 
 def test_download_s3_folder_handles_empty_listing(tmp_path):
     """An empty prefix should be a no-op, not an error."""
-    with mock.patch("jina_sagemaker.helper.boto3.resource") as mock_resource:
-        bucket = _set_up_bucket(mock_resource, keys=[])
+    resource_patch, client_patch = _patch_boto()
+    with resource_patch as mr, client_patch as mc:
+        _set_up_listing(mr, keys=[])
+
         download_s3_folder("s3://bucket/prefix", local_dir=str(tmp_path))
-    assert bucket.download_file.call_count == 0
+
+    # We never build the low-level client when there's nothing to do.
+    mc.assert_not_called()


### PR DESCRIPTION
Resolves elastic/sefo-gcp#452.

## Context

\`download_s3_folder\` used a serial \`for\`-loop that called \`Bucket.download_file\` once per object. For batch-transform outputs with thousands of small JSON files this was the dominant cost of pulling results to a local path — each \`download_file\` is mostly socket-IO wait, so the loop spent almost all its time blocked on the network.

## Description

Switch to a two-pass implementation:
1. Enumerate the S3 listing and create target directories serially. \`os.makedirs(parent, exist_ok=True)\` against a shared parent races when called from multiple threads; the listing + directory-creation cost is negligible relative to the downloads.
2. Submit each download into a \`ThreadPoolExecutor\` (default 16 workers, capped to the actual object count). \`download_file\` releases the GIL on socket waits, so thread-level parallelism converts directly into bandwidth.

\`as_completed\` + \`fut.result()\` re-raises the first worker exception, so partial failures surface as a single clean error to the caller instead of leaving a half-downloaded folder with no signal.

## Changes in the Codebase

\`jina_sagemaker/helper.py\`:
- \`download_s3_folder(path, local_dir=None, max_workers=16)\` — new \`max_workers\` parameter; default 16.
- Replace the serial loop with a two-pass enumerate-then-parallel-download implementation.
- \`obj.key.endswith(\"/\")\` instead of \`obj.key[-1] == \"/\"\` (no IndexError on empty key).
- \`os.makedirs(parent, exist_ok=True)\` instead of the if-not-exists guard (atomic, one fewer stat call).
- \`local_dir\` typed as \`Optional[str]\` instead of the previous \`str = None\` type/default mismatch.

\`tests/test_helper.py\`: 5 new tests
- Every non-folder key gets downloaded with the right local target path.
- Keys ending in \`/\` (S3 folder markers, including nested ones) are skipped.
- Downloads genuinely run concurrently — verified with a \`threading.Barrier(n)\` that only trips when all \`n\` workers run at the same time. If the implementation were still serial, the barrier would never trip and the test would time out.
- A worker exception is propagated to the caller, not silently swallowed.
- An empty listing is a no-op, not an error.

## Changes Outside the Codebase

None.

## Testing

\`pytest -q\` → 56 passed (50 existing + 5 new \`download_s3_folder\` + 1 net new of the existing class).
\`black --check .\`, \`isort --check .\`, \`flake8\` (syntax + style + complexity ≤ 20) → all clean.

## Additional Information

- 16 was chosen as the default because most real-world batch-transform output folders are a few hundred files and 16 saturates the typical SageMaker endpoint's network without thrashing. The parameter is exposed so callers with very large folders can dial it up.
- Customers who currently pass only \`(path, local_dir)\` positionally see zero behavioural difference except faster downloads. The new \`max_workers\` argument is keyword-friendly.