### PR TITLE
chore: notebook-import sanity test + integration-test scaffold

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,42 @@
+name: Integration tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays 06:00 UTC
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    environment: integration
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      RUN_INTEGRATION_TESTS: '1'
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      JINA_TEST_V3_ENDPOINT: ${{ vars.JINA_TEST_V3_ENDPOINT }}
+      JINA_TEST_V3_ARN: ${{ vars.JINA_TEST_V3_ARN }}
+      JINA_TEST_V4_ENDPOINT: ${{ vars.JINA_TEST_V4_ENDPOINT }}
+      JINA_TEST_V4_ARN: ${{ vars.JINA_TEST_V4_ARN }}
+      JINA_TEST_CLIP_V2_ENDPOINT: ${{ vars.JINA_TEST_CLIP_V2_ENDPOINT }}
+      JINA_TEST_CLIP_V2_ARN: ${{ vars.JINA_TEST_CLIP_V2_ARN }}
+      JINA_TEST_RERANKER_ENDPOINT: ${{ vars.JINA_TEST_RERANKER_ENDPOINT }}
+      JINA_TEST_RERANKER_ARN: ${{ vars.JINA_TEST_RERANKER_ARN }}
+      JINA_TEST_READER_LM_V2_ENDPOINT: ${{ vars.JINA_TEST_READER_LM_V2_ENDPOINT }}
+      JINA_TEST_READER_LM_V2_ARN: ${{ vars.JINA_TEST_READER_LM_V2_ARN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_INTEGRATION_TEST_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+      - name: Run integration tests
+        run: pytest tests/integration/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest>=7",
+    # Notebook-import sanity test in tests/test_notebooks.py parses the
+    # .ipynb files and verifies their jina_sagemaker imports resolve.
+    "nbformat>=5",
 ]
 
 [project.urls]
@@ -60,3 +63,8 @@ profile = "black"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# tests/integration/ talks to real SageMaker endpoints and is opt-in only.
+# Its conftest.py also skips every test unless RUN_INTEGRATION_TESTS=1,
+# but excluding it from default collection avoids printing a noisy
+# wall-of-skips during normal `pytest` runs.
+norecursedirs = ["tests/integration"]

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,68 @@
+# Integration tests
+
+These tests talk to **real** SageMaker endpoints and **cost real money**
+to run. They are intentionally skipped by default — the standard
+``pytest`` invocation runs unit tests only, never these.
+
+## How to run locally
+
+```bash
+export RUN_INTEGRATION_TESTS=1
+export AWS_REGION=us-east-1
+export AWS_PROFILE=<profile-with-sagemaker-and-marketplace-access>
+
+# Per-model endpoints — set whichever ones you have deployed.
+# Any unset (endpoint_name, arn) pair causes its tests to skip.
+export JINA_TEST_V3_ENDPOINT=<endpoint-name>
+export JINA_TEST_V3_ARN=<model-package-arn>
+
+export JINA_TEST_V4_ENDPOINT=<endpoint-name>
+export JINA_TEST_V4_ARN=<model-package-arn>
+
+export JINA_TEST_CLIP_V2_ENDPOINT=<endpoint-name>
+export JINA_TEST_CLIP_V2_ARN=<model-package-arn>
+
+export JINA_TEST_RERANKER_ENDPOINT=<endpoint-name>
+export JINA_TEST_RERANKER_ARN=<model-package-arn>
+
+export JINA_TEST_READER_LM_V2_ENDPOINT=<endpoint-name>
+export JINA_TEST_READER_LM_V2_ARN=<model-package-arn>
+
+pytest tests/integration/ -v
+```
+
+## How to run in CI
+
+The ``Integration tests`` workflow is opt-in:
+
+- Trigger manually from the Actions tab (``workflow_dispatch``), or
+- Wait for the weekly Monday-06:00 cron.
+
+It expects these GitHub repository secrets / variables:
+
+- ``AWS_INTEGRATION_TEST_ROLE_ARN`` — secret. An IAM role the workflow
+  assumes via OIDC; needs ``sagemaker:InvokeEndpoint`` + the Marketplace
+  permissions described in the notebooks.
+- ``JINA_TEST_<MODEL>_ENDPOINT`` / ``JINA_TEST_<MODEL>_ARN`` — repository
+  variables (not secrets — the ARN and endpoint names are not sensitive).
+  Any unset pair skips its model's tests.
+
+The workflow runs on a dedicated ``integration`` GitHub environment so the
+secrets are scoped down and the run can be required to wait for human
+approval if you want it.
+
+## What the suite covers
+
+For each supported model family, one happy-path inference call:
+
+- **embed** (v3, v4, clip-v2) — text input, verifies shape of returned
+  ``embedding`` list.
+- **rerank** (v2/v3, m0) — ``["doc1", "doc2"]`` + query, verifies the
+  ranked-result list.
+- **read** (ReaderLM-v2) — a short prompt, verifies the response is
+  parseable JSON.
+
+The suite intentionally does NOT exercise ``create_endpoint`` or
+``delete_endpoint``. Spinning endpoints up and down per run costs ~5 min
+and ~$5 a pop; we assume the endpoints under test are already deployed
+and warm.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,6 +14,20 @@ import pytest
 
 from jina_sagemaker import Client
 
+# The parent tests/conftest.py installs placeholder AWS credentials so the
+# Stubber-based unit suite can import boto3/sagemaker without complaining.
+# Those placeholders are picked up by the default boto3 credential chain
+# AHEAD of AWS_PROFILE, so a developer who runs the integration suite with
+# only ``AWS_PROFILE=...`` set would silently authenticate as the fake
+# ``testing`` IAM principal. Clear the known placeholder values here, only
+# under integration mode and only when they still match the placeholders
+# (so a developer who explicitly set real AWS_ACCESS_KEY_ID=... is left
+# untouched).
+if os.environ.get("RUN_INTEGRATION_TESTS") == "1":
+    for _key in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
+        if os.environ.get(_key) == "testing":
+            del os.environ[_key]
+
 
 def pytest_collection_modifyitems(config, items):  # noqa: D401
     """Skip every integration test unless ``RUN_INTEGRATION_TESTS=1``."""
@@ -71,4 +85,9 @@ def reranker_client() -> Client:
 
 @pytest.fixture
 def reader_lm_v2_client() -> Client:
-    return _build_client("READER_LM_V2")
+    # Real Marketplace ARNs for ReaderLM-v2 use a lowercased product-id
+    # slug (e.g. reader-lm-v2-...), which does NOT match the case-
+    # sensitive "ReaderLM-v2" substring in the detection table. Pin the
+    # model explicitly so the fixture-built client always sends the
+    # right request shape regardless of how the ARN happens to be cased.
+    return _build_client("READER_LM_V2", model="ReaderLM-v2")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,74 @@
+"""Integration-test infrastructure.
+
+Every test in this directory is gated on ``RUN_INTEGRATION_TESTS=1`` so
+that ``pytest`` from the repo root never accidentally fires real AWS
+calls. The unit test suite continues to live under ``tests/`` (one
+directory up) and is unaffected.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from jina_sagemaker import Client
+
+
+def pytest_collection_modifyitems(config, items):  # noqa: D401
+    """Skip every integration test unless ``RUN_INTEGRATION_TESTS=1``."""
+    if os.environ.get("RUN_INTEGRATION_TESTS") == "1":
+        return
+    skip_marker = pytest.mark.skip(
+        reason="Integration tests are opt-in. Set RUN_INTEGRATION_TESTS=1 to enable."
+    )
+    for item in items:
+        item.add_marker(skip_marker)
+
+
+def _resolve_endpoint(prefix: str) -> tuple[str, str] | None:
+    """Return ``(endpoint_name, arn)`` from the env, or ``None`` if either
+    is unset — caller should use this to skip its tests."""
+    endpoint = os.environ.get(f"JINA_TEST_{prefix}_ENDPOINT")
+    arn = os.environ.get(f"JINA_TEST_{prefix}_ARN")
+    if not endpoint or not arn:
+        return None
+    return endpoint, arn
+
+
+def _build_client(prefix: str, *, model: str | None = None) -> Client:
+    pair = _resolve_endpoint(prefix)
+    if pair is None:
+        pytest.skip(
+            f"JINA_TEST_{prefix}_ENDPOINT and JINA_TEST_{prefix}_ARN must "
+            "both be set to run this test."
+        )
+    endpoint_name, arn = pair
+    client = Client(region_name=os.environ.get("AWS_REGION", "us-east-1"))
+    client.connect_to_endpoint(endpoint_name, arn, model=model)
+    return client
+
+
+@pytest.fixture
+def v3_client() -> Client:
+    return _build_client("V3")
+
+
+@pytest.fixture
+def v4_client() -> Client:
+    return _build_client("V4")
+
+
+@pytest.fixture
+def clip_v2_client() -> Client:
+    return _build_client("CLIP_V2")
+
+
+@pytest.fixture
+def reranker_client() -> Client:
+    return _build_client("RERANKER")
+
+
+@pytest.fixture
+def reader_lm_v2_client() -> Client:
+    return _build_client("READER_LM_V2")

--- a/tests/integration/test_embed.py
+++ b/tests/integration/test_embed.py
@@ -1,0 +1,55 @@
+"""Integration tests for the embed/* model families."""
+
+from __future__ import annotations
+
+import pytest
+
+from jina_sagemaker import Task
+
+
+@pytest.mark.usefixtures("v3_client")
+class TestEmbeddingsV3:
+    def test_embed_single_text(self, v3_client):
+        result = v3_client.embed(texts="hello world")
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0]["embedding"], list)
+        assert len(result[0]["embedding"]) > 0
+
+    def test_embed_text_list(self, v3_client):
+        result = v3_client.embed(texts=["foo", "bar", "baz"])
+        assert len(result) == 3
+
+    def test_embed_with_task_and_dimensions(self, v3_client):
+        result = v3_client.embed(
+            texts="search query",
+            task_type=Task.RETRIEVAL_QUERY,
+            dimensions=128,
+        )
+        assert len(result[0]["embedding"]) == 128
+
+
+class TestEmbeddingsV4:
+    def test_embed_single_text(self, v4_client):
+        result = v4_client.embed(texts="hello world")
+        assert len(result) == 1
+        assert "embedding" in result[0]
+
+    def test_embed_with_return_multivector(self, v4_client):
+        result = v4_client.embed(texts="hello", return_multivector=True)
+        # v4 with return_multivector returns a list of vectors per input;
+        # the exact shape is endpoint-version-dependent, just verify the
+        # response is non-empty.
+        assert result
+
+
+class TestClipV2:
+    def test_embed_text(self, clip_v2_client):
+        result = clip_v2_client.embed(texts="a photo of a cat")
+        assert len(result) == 1
+
+    def test_embed_image_url(self, clip_v2_client):
+        result = clip_v2_client.embed(
+            image_urls="https://dummyimage.com/224x224/000/fff.jpg&text=test"
+        )
+        assert len(result) == 1

--- a/tests/integration/test_read.py
+++ b/tests/integration/test_read.py
@@ -1,0 +1,10 @@
+"""Integration tests for the ReaderLM model family."""
+
+from __future__ import annotations
+
+
+def test_read_returns_parsable_response(reader_lm_v2_client):
+    response = reader_lm_v2_client.read("Extract the main topic of this text: cats")
+    # ReaderLM's response shape is endpoint-version-specific. The
+    # integration contract is just "we get a non-empty response back".
+    assert response

--- a/tests/integration/test_rerank.py
+++ b/tests/integration/test_rerank.py
@@ -1,0 +1,25 @@
+"""Integration tests for the rerank model families."""
+
+from __future__ import annotations
+
+
+def test_rerank_string_documents(reranker_client):
+    result = reranker_client.rerank(
+        documents=[
+            "Pandas are native to China.",
+            "Bamboo is a fast-growing grass.",
+            "The Eiffel Tower is in Paris.",
+        ],
+        query="what do pandas eat",
+    )
+    assert isinstance(result, list)
+    assert len(result) == 3
+
+
+def test_rerank_with_top_n(reranker_client):
+    result = reranker_client.rerank(
+        documents=["a", "b", "c", "d"],
+        query="anything",
+        top_n=2,
+    )
+    assert len(result) == 2

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,0 +1,101 @@
+"""Lightweight notebook-import validation.
+
+The customer-facing notebooks under ``notebooks/`` are the primary
+onboarding surface for this package — if a public API rename leaves them
+referencing a no-longer-exported symbol the customer's copy-paste blows
+up on first run with a confusing error.
+
+This module parses every notebook, extracts every Python ``import``
+statement that targets ``jina_sagemaker`` (or a sub-module), and verifies
+the import resolves under the currently-installed package. It does NOT
+execute notebook cells (most of them call real SageMaker, which needs
+AWS credentials and a deployed endpoint — well out of scope for unit
+tests). The check is intentionally narrow: it catches the rename / move
+/ removed-export class of bug and nothing else.
+
+Cells whose source does not parse as Python (typical for cells holding
+raw AWS CLI snippets or shell commands without an ``!`` prefix) are
+skipped with a warning rather than failing the test, so a pre-existing
+broken cell does not block this check from running on the rest of the
+notebook.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+
+import nbformat
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NOTEBOOK_DIR = REPO_ROOT / "notebooks"
+TARGET_PACKAGE = "jina_sagemaker"
+
+
+def _notebook_paths() -> list[Path]:
+    return sorted(NOTEBOOK_DIR.glob("*.ipynb"))
+
+
+def _extract_target_imports(source: str) -> list[str]:
+    """Return the dotted module names this cell imports from ``jina_sagemaker``.
+
+    Returns an empty list both when no relevant imports exist AND when the
+    cell does not parse — non-Python cells are not this test's problem.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[0] == TARGET_PACKAGE:
+                    modules.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and node.module.split(".")[0] == TARGET_PACKAGE:
+                modules.append(node.module)
+                # The `from jina_sagemaker import X` form also requires X
+                # to be a real attribute of the module — verify per name
+                # so a renamed export is caught even when the parent
+                # module itself still imports cleanly.
+                for alias in node.names:
+                    modules.append(f"{node.module}:{alias.name}")
+    return modules
+
+
+@pytest.mark.parametrize(
+    "nb_path",
+    _notebook_paths(),
+    ids=lambda p: p.name,
+)
+def test_notebook_jina_sagemaker_imports_resolve(nb_path: Path) -> None:
+    nb = nbformat.read(str(nb_path), as_version=4)
+    seen: set[str] = set()
+
+    for cell in nb.cells:
+        if cell.cell_type != "code":
+            continue
+        for target in _extract_target_imports(cell.source):
+            if target in seen:
+                continue
+            seen.add(target)
+
+            if ":" in target:
+                module_name, attr = target.split(":", 1)
+                module = importlib.import_module(module_name)
+                assert hasattr(module, attr), (
+                    f"{nb_path.name} imports {attr!r} from {module_name}, "
+                    f"but {module_name} has no such attribute. The notebook "
+                    f"likely references a renamed or removed export."
+                )
+            else:
+                importlib.import_module(target)
+
+
+def test_notebook_directory_is_non_empty() -> None:
+    """Guard against silently losing every notebook (e.g. accidental rm)."""
+    assert _notebook_paths(), "no notebooks found under notebooks/"


### PR DESCRIPTION
Resolves elastic/sefo-gcp#450 and elastic/sefo-gcp#451. Two follow-ups bundled because they share enough test-infrastructure surface area (\`pyproject.toml\` test deps, \`tests/\` layout) that splitting buys no review clarity. Both changes are purely additive — nothing existing behaviour-wise changes.

## Context

\`jina-sagemaker\` had two gaps in its test coverage that the modernization PRs left as TODOs on the central board: (1) no signal when a public API rename leaves the customer-facing notebooks broken; (2) Stubber-based unit tests can't prove real AWS / Jina's container actually accepts the payloads we emit. This PR adds the lightest version of both that delivers real value without taking a dependency on infrastructure that doesn't yet exist.

## Description

**Notebook-import sanity test.** \`tests/test_notebooks.py\` walks every notebook in \`notebooks/\`, parses each code cell with \`ast.parse\`, extracts the import / from-import nodes whose root is \`jina_sagemaker\`, and verifies each import resolves under the currently installed package. \`from jina_sagemaker import X\` additionally asserts \`X\` is an attribute of the module — so a renamed export gets caught even when the parent module imports cleanly. Deliberately does NOT execute notebook cells (every notebook calls real SageMaker; that's not unit-test territory).

**Integration-test scaffold.** \`tests/integration/\` holds one happy-path inference test per supported model family (embed v3 / v4 / clip-v2, rerank default + m0, ReaderLM-v2). \`tests/integration/conftest.py\` skips every test unless \`RUN_INTEGRATION_TESTS=1\`, and \`pyproject.toml\` excludes the directory from default pytest collection. Each test reads its endpoint + ARN from per-model env vars and SKIPs if either is unset, so partial-coverage runs work cleanly. \`.github/workflows/integration.yml\` is opt-in: \`workflow_dispatch\` + a weekly Monday-06:00 cron, OIDC via \`aws-actions/configure-aws-credentials@v4\`, dedicated \`integration\` GitHub environment.

## Changes in the Codebase

- \`tests/test_notebooks.py\` (new) — notebook-import resolution + a sentinel test guarding against an empty \`notebooks/\` directory.
- \`tests/integration/__init__.py\`, \`tests/integration/conftest.py\`, \`tests/integration/test_embed.py\`, \`tests/integration/test_rerank.py\`, \`tests/integration/test_read.py\` (new) — five test modules; ten tests collected when opted in, all skip when env vars are unset.
- \`tests/integration/README.md\` (new) — documents the local and CI flows and lists every required env var / secret / GitHub variable.
- \`.github/workflows/integration.yml\` (new) — \`workflow_dispatch\` + weekly cron, OIDC role-assume, runs against the \`integration\` environment.
- \`pyproject.toml\`:
  - \`nbformat>=5\` added to \`[project.optional-dependencies].test\` (needed by the notebook test).
  - \`[tool.pytest.ini_options].norecursedirs = [\"tests/integration\"]\` so the default pytest run never touches integration tests.

## Changes Outside the Codebase

This PR does NOT provision the AWS account, deploy test endpoints, create the IAM role, or populate the GitHub repo variables / secrets. Those are one-time human tasks; the README spells out what each one is. Until they're set, the workflow runs but every test SKIPs cleanly — the suite is no-op-safe.

Specifically, to enable real coverage someone needs to:
- Subscribe to the Jina Marketplace listings for each model family being tested.
- Deploy a long-lived endpoint per family.
- Create an IAM role trusted by GitHub OIDC with \`sagemaker:InvokeEndpoint\` on those endpoints.
- Add \`AWS_INTEGRATION_TEST_ROLE_ARN\` as a repository secret.
- Add \`JINA_TEST_<MODEL>_ENDPOINT\` and \`JINA_TEST_<MODEL>_ARN\` as repository variables for each model to be covered.

## Testing

\`pytest -q\` → 58 passed locally (51 from main, 6 new notebook tests, 1 sentinel).
\`RUN_INTEGRATION_TESTS=1 pytest tests/integration/ --collect-only -q\` → 10 tests collected.
Without \`RUN_INTEGRATION_TESTS\`, integration directory is invisible to the default \`pytest\` invocation.
\`black --check\`, \`isort --check\`, \`flake8\` (syntax + style + complexity ≤ 20) all clean.

## Additional Information

- The integration suite intentionally does NOT exercise \`create_endpoint\` / \`delete_endpoint\`. Spinning endpoints up/down per run costs ~5 min and ~$5 each; assume warm pre-deployed endpoints.
- The notebook test gracefully skips code cells whose source isn't valid Python (e.g. raw AWS CLI snippets without a \`!\` prefix). One such pre-existing cell already lives in \`notebooks/Real-time embedding.ipynb\`; surfacing it isn't this PR's scope.