### PR TITLE
chore: migrate from black + isort + flake8 to ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install linters
-        run: pip install black isort flake8
-      - name: black --check
-        run: black --check .
-      - name: isort --check
-        run: isort --check .
-      - name: flake8 syntax errors
-        run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude .git,__pycache__,build,dist
-      - name: flake8 style
-        run: flake8 . --count --max-complexity=20 --max-line-length=127 --statistics --exclude .git,__pycache__,build,dist
+      - name: Install ruff
+        run: pip install ruff
+      - name: ruff format --check
+        run: ruff format --check .
+      - name: ruff check
+        run: ruff check .
 
   tests:
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,7 @@
 repos:
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.4
     hooks:
-      - id: isort
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
-    hooks:
-      - id: black
-        types: [python]
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -45,7 +45,15 @@ pip install -e .[test]
 pytest
 ```
 
-Formatting and linting use `black`, `isort`, and `flake8`; configuration lives in `pyproject.toml`. A pre-commit hook is provided:
+Formatting and linting use [`ruff`](https://github.com/astral-sh/ruff); configuration lives in `pyproject.toml`:
+
+```bash
+pip install ruff
+ruff format .       # apply formatting
+ruff check --fix .  # apply lint autofixes
+```
+
+A pre-commit hook is provided:
 
 ```bash
 pip install pre-commit

--- a/jina_sagemaker/client.py
+++ b/jina_sagemaker/client.py
@@ -80,9 +80,7 @@ _DETECTION_TABLE: List[Tuple[str, ModelSpec]] = [
 # Accepts the canonical ``ModelSpec.name`` as an explicit override when the
 # caller passes ``model=`` to ``connect_to_endpoint`` / ``create_endpoint`` /
 # ``create_async_endpoint``. The override path skips ARN detection entirely.
-_OVERRIDE_TABLE: Dict[str, ModelSpec] = {
-    spec.name: spec for _, spec in _DETECTION_TABLE
-}
+_OVERRIDE_TABLE: Dict[str, ModelSpec] = {spec.name: spec for _, spec in _DETECTION_TABLE}
 
 
 def _resolve_model(arn: str, override: Optional[str] = None) -> ModelSpec:
@@ -101,9 +99,7 @@ def _resolve_model(arn: str, override: Optional[str] = None) -> ModelSpec:
     if override is not None:
         if override not in _OVERRIDE_TABLE:
             known = sorted(_OVERRIDE_TABLE)
-            raise ValueError(
-                f"Unknown model override {override!r}. Known values: {known}"
-            )
+            raise ValueError(f"Unknown model override {override!r}. Known values: {known}")
         return _OVERRIDE_TABLE[override]
 
     for slug, spec in _DETECTION_TABLE:
@@ -182,9 +178,7 @@ class Client:
             raise Exception(f"Endpoint {endpoint_name} does not exist.")
         self._endpoint_name = endpoint_name
         self._variant_name = "AllTraffic"
-        self._resource_id = "endpoint/{}/variant/{}".format(
-            self._endpoint_name, self._variant_name
-        )
+        self._resource_id = "endpoint/{}/variant/{}".format(self._endpoint_name, self._variant_name)
         self._arn = arn
         self._model_spec = _resolve_model(arn, override=model)
 
@@ -251,9 +245,7 @@ class Client:
                 self.connect_to_endpoint(endpoint_name, arn, model=model)
                 self.delete_endpoint()
             else:
-                raise Exception(
-                    f"Endpoint {endpoint_name} already exists and recreate={recreate}."
-                )
+                raise Exception(f"Endpoint {endpoint_name} already exists and recreate={recreate}.")
 
         async_inference_config: Dict = {
             "OutputConfig": {
@@ -263,13 +255,9 @@ class Client:
         if success_topic or error_topic:
             async_inference_config["OutputConfig"]["NotificationConfig"] = {}
             if success_topic:
-                async_inference_config["OutputConfig"]["NotificationConfig"][
-                    "SuccessTopic"
-                ] = success_topic
+                async_inference_config["OutputConfig"]["NotificationConfig"]["SuccessTopic"] = success_topic
             if error_topic:
-                async_inference_config["OutputConfig"]["NotificationConfig"][
-                    "ErrorTopic"
-                ] = error_topic
+                async_inference_config["OutputConfig"]["NotificationConfig"]["ErrorTopic"] = error_topic
 
         self._sm_client.create_endpoint_config(
             EndpointConfigName=endpoint_name,
@@ -333,9 +321,7 @@ class Client:
                 self.connect_to_endpoint(endpoint_name, arn, model=model)
                 self.delete_endpoint()
             else:
-                raise Exception(
-                    f"Endpoint {endpoint_name} already exists and recreate={recreate}."
-                )
+                raise Exception(f"Endpoint {endpoint_name} already exists and recreate={recreate}.")
 
         try:
             self._sm_client.delete_endpoint_config(EndpointConfigName=endpoint_name)
@@ -427,9 +413,7 @@ class Client:
             if not os.path.exists(input_path):
                 raise FileNotFoundError(f"Input path {input_path} does not exist.")
             csv_path_with_ids = prefix_csv_with_ids(input_path=input_path)
-            s3_input_path = self._sm_session.upload_data(
-                path=csv_path_with_ids, key_prefix=f"input/{uid}"
-            )
+            s3_input_path = self._sm_session.upload_data(path=csv_path_with_ids, key_prefix=f"input/{uid}")
             log.info(f"Input file uploaded to {s3_input_path}.")
         else:
             s3_input_path = input_path
@@ -716,17 +700,10 @@ class Client:
 
         if self._endpoint_config_name is not None:
             try:
-                self._sm_client.delete_endpoint_config(
-                    EndpointConfigName=self._endpoint_config_name
-                )
-                log.info(
-                    f"Deleted endpoint configuration: {self._endpoint_config_name}"
-                )
+                self._sm_client.delete_endpoint_config(EndpointConfigName=self._endpoint_config_name)
+                log.info(f"Deleted endpoint configuration: {self._endpoint_config_name}")
             except ClientError:
-                log.info(
-                    f"Endpoint configuration '{self._endpoint_config_name}' "
-                    "not found, skipping deletion."
-                )
+                log.info(f"Endpoint configuration '{self._endpoint_config_name}' not found, skipping deletion.")
 
         if self._model_name is not None:
             try:

--- a/jina_sagemaker/helper.py
+++ b/jina_sagemaker/helper.py
@@ -97,11 +97,7 @@ def download_s3_folder(
     for obj in bucket.objects.filter(Prefix=s3_folder):
         if obj.key.endswith("/"):
             continue
-        target = (
-            obj.key
-            if local_dir is None
-            else os.path.join(local_dir, os.path.relpath(obj.key, s3_folder))
-        )
+        target = obj.key if local_dir is None else os.path.join(local_dir, os.path.relpath(obj.key, s3_folder))
         parent = os.path.dirname(target)
         if parent:
             os.makedirs(parent, exist_ok=True)
@@ -115,9 +111,6 @@ def download_s3_folder(
     # which is why we don't reuse ``bucket.download_file`` here.
     s3_client = boto3.client("s3")
     with ThreadPoolExecutor(max_workers=min(max_workers, len(tasks))) as pool:
-        futures = [
-            pool.submit(s3_client.download_file, bucket_name, key, target)
-            for key, target in tasks
-        ]
+        futures = [pool.submit(s3_client.download_file, bucket_name, key, target) for key, target in tasks]
         for fut in as_completed(futures):
             fut.result()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,32 @@ include = [
 [tool.hatch.build.targets.wheel]
 packages = ["jina_sagemaker"]
 
-[tool.black]
-skip-string-normalization = true
-target-version = ["py310", "py311", "py312", "py313"]
+[tool.ruff]
+line-length = 127
+target-version = "py310"
+# Notebooks and examples are customer-facing reference material; their
+# formatting is curated by the docs team, not enforced by CI.
+extend-exclude = ["notebooks", "examples"]
 
-[tool.isort]
-profile = "black"
+[tool.ruff.format]
+# Match the prior `black -S` (skip-string-normalization) behaviour so this
+# swap does not churn every single- vs double-quoted literal in the repo.
+quote-style = "preserve"
+
+[tool.ruff.lint]
+# E + W: pycodestyle errors/warnings (covers the old flake8 E9 set).
+# F:     pyflakes (undefined names, unused imports, etc. — old F63/F7/F82).
+# I:     isort import-order rules (replaces the standalone isort tool).
+# C90:   mccabe complexity (replaces flake8 --max-complexity).
+select = ["E", "F", "I", "C90", "W"]
+
+[tool.ruff.lint.mccabe]
+# Matches the previous flake8 --max-complexity=20 cap. Lower this once
+# create_async_endpoint and embed() are simpler.
+max-complexity = 20
+
+[tool.ruff.lint.isort]
+known-first-party = ["jina_sagemaker"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,9 +33,7 @@ def pytest_collection_modifyitems(config, items):  # noqa: D401
     """Skip every integration test unless ``RUN_INTEGRATION_TESTS=1``."""
     if os.environ.get("RUN_INTEGRATION_TESTS") == "1":
         return
-    skip_marker = pytest.mark.skip(
-        reason="Integration tests are opt-in. Set RUN_INTEGRATION_TESTS=1 to enable."
-    )
+    skip_marker = pytest.mark.skip(reason="Integration tests are opt-in. Set RUN_INTEGRATION_TESTS=1 to enable.")
     for item in items:
         item.add_marker(skip_marker)
 
@@ -53,10 +51,7 @@ def _resolve_endpoint(prefix: str) -> tuple[str, str] | None:
 def _build_client(prefix: str, *, model: str | None = None) -> Client:
     pair = _resolve_endpoint(prefix)
     if pair is None:
-        pytest.skip(
-            f"JINA_TEST_{prefix}_ENDPOINT and JINA_TEST_{prefix}_ARN must "
-            "both be set to run this test."
-        )
+        pytest.skip(f"JINA_TEST_{prefix}_ENDPOINT and JINA_TEST_{prefix}_ARN must both be set to run this test.")
     endpoint_name, arn = pair
     client = Client(region_name=os.environ.get("AWS_REGION", "us-east-1"))
     client.connect_to_endpoint(endpoint_name, arn, model=model)

--- a/tests/integration/test_embed.py
+++ b/tests/integration/test_embed.py
@@ -49,7 +49,5 @@ class TestClipV2:
         assert len(result) == 1
 
     def test_embed_image_url(self, clip_v2_client):
-        result = clip_v2_client.embed(
-            image_urls="https://dummyimage.com/224x224/000/fff.jpg&text=test"
-        )
+        result = clip_v2_client.embed(image_urls="https://dummyimage.com/224x224/000/fff.jpg&text=test")
         assert len(result) == 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -167,9 +167,7 @@ def test_embed_no_endpoint_raises(client):
 
 def test_embed_v3_text_default_task(client):
     _connect(client, ARN_V3)
-    response_body = _json_streaming(
-        _invoke_response_data([{"index": 0, "embedding": [0.1]}])
-    )
+    response_body = _json_streaming(_invoke_response_data([{"index": 0, "embedding": [0.1]}]))
     expected_body = json.dumps(
         {
             "data": [{"text": "hello"}],
@@ -463,9 +461,7 @@ def test_embed_v2_no_parameters_block(client):
 
 def test_embed_colbert_query(client):
     _connect(client, ARN_COLBERT)
-    expected_body = json.dumps(
-        {"data": {"text": "find this"}, "parameters": {"input_type": "query"}}
-    )
+    expected_body = json.dumps({"data": {"text": "find this"}, "parameters": {"input_type": "query"}})
     with Stubber(client._sm_runtime_client) as stub:
         stub.add_response(
             "invoke_endpoint",
@@ -518,9 +514,7 @@ def test_rerank_no_endpoint_raises(client):
 
 def test_rerank_strings_normalized_to_dicts(client):
     _connect(client, ARN_RERANKER)
-    expected_body = json.dumps(
-        {"data": {"documents": [{"text": "a"}, {"text": "b"}], "query": "q"}}
-    )
+    expected_body = json.dumps({"data": {"documents": [{"text": "a"}, {"text": "b"}], "query": "q"}})
     with Stubber(client._sm_runtime_client) as stub:
         stub.add_response(
             "invoke_endpoint",
@@ -695,9 +689,7 @@ def test_read_async_model_dispatch(client, arn, model_name):
         result = client.read_async("hi", input_s3)
 
     boto_client.assert_called_once_with("s3", region_name="us-east-1")
-    s3_mock.put_object.assert_called_once_with(
-        Bucket="bucket", Key="prefix/input.json", Body=expected_body
-    )
+    s3_mock.put_object.assert_called_once_with(Bucket="bucket", Key="prefix/input.json", Body=expected_body)
     assert result == {
         "OutputLocation": "s3://bucket/output/result.out",
         "InputLocation": input_s3,
@@ -721,9 +713,7 @@ def test_delete_endpoint_full(client):
 
     with Stubber(client._sm_client) as stub:
         stub.add_response("delete_endpoint", {}, {"EndpointName": "test-endpoint"})
-        stub.add_response(
-            "delete_endpoint_config", {}, {"EndpointConfigName": "test-endpoint"}
-        )
+        stub.add_response("delete_endpoint_config", {}, {"EndpointConfigName": "test-endpoint"})
         stub.add_response("delete_model", {}, {"ModelName": "test-endpoint"})
         client.delete_endpoint()
 
@@ -783,9 +773,7 @@ def test_connect_to_endpoint_with_model_override(client):
             _describe_endpoint_response("test-endpoint"),
             {"EndpointName": "test-endpoint"},
         )
-        client.connect_to_endpoint(
-            "test-endpoint", ARN_CLIP_V2, model="jina-embeddings-v4"
-        )
+        client.connect_to_endpoint("test-endpoint", ARN_CLIP_V2, model="jina-embeddings-v4")
     assert client._model_spec is not None
     assert client._model_spec.family == "embeddings-v4"
 

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -25,9 +25,7 @@ def _read_rows(path):
 
 
 def test_prefix_csv_adds_uuid_when_missing():
-    with tempfile.NamedTemporaryFile(
-        mode="w", delete=False, suffix=".csv", encoding="utf-8"
-    ) as f:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv", encoding="utf-8") as f:
         f.write(SAMPLE_CSV_NO_IDS)
         input_path = f.name
 
@@ -46,9 +44,7 @@ def test_prefix_csv_adds_uuid_when_missing():
 
 
 def test_prefix_csv_raises_on_empty_input():
-    with tempfile.NamedTemporaryFile(
-        mode="w", delete=False, suffix=".csv", encoding="utf-8"
-    ) as f:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv", encoding="utf-8") as f:
         input_path = f.name
         # leave file empty
 
@@ -61,9 +57,7 @@ def test_prefix_csv_raises_on_empty_input():
 
 def test_prefix_csv_handles_blank_leading_line():
     """A CSV whose first line is blank must NOT crash on first_row[0]."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", delete=False, suffix=".csv", encoding="utf-8"
-    ) as f:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv", encoding="utf-8") as f:
         f.write("\nHow is the weather today?\nWhen are you open?\n")
         input_path = f.name
 
@@ -84,9 +78,7 @@ def test_prefix_csv_handles_blank_leading_line():
 
 
 def test_prefix_csv_preserves_existing_uuids():
-    with tempfile.NamedTemporaryFile(
-        mode="w", delete=False, suffix=".csv", encoding="utf-8"
-    ) as f:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv", encoding="utf-8") as f:
         f.write(SAMPLE_CSV_WITH_IDS)
         input_path = f.name
 


### PR DESCRIPTION
Resolves elastic/sefo-gcp#453.

## Context

Replaces the three-tool linting stack (\`black\` + \`isort\` + \`flake8\`) with a single \`ruff\` invocation that covers all three. Pure tooling churn — no behaviour change in the package itself. The motivation is fewer tools to install in CI, a single source of truth for config in \`pyproject.toml\`, and considerably faster checks (one Rust binary vs three Python tools each with their own startup overhead).

## Description

\`ruff\` handles formatting (replacing \`black\`), import ordering (replacing \`isort\`), and the pyflakes / pycodestyle / mccabe rule families (replacing \`flake8\`). One pre-commit hook, one CI step, one config block.

## Changes in the Codebase

\`pyproject.toml\`:
- Drops \`[tool.black]\` and \`[tool.isort]\`.
- Adds \`[tool.ruff]\` with \`line-length = 127\` (matches old flake8 \`--max-line-length\`), \`target-version = \"py310\"\` (matches \`[tool.black].target-version\`), and \`extend-exclude = [\"notebooks\", \"examples\"]\`.
- \`[tool.ruff.format].quote-style = \"preserve\"\` — keeps the prior \`black -S\` (\`--skip-string-normalization\`) semantics so existing single-quoted literals like \`__version__ = '0.0.46'\` aren't churned to double quotes.
- \`[tool.ruff.lint].select = [\"E\", \"F\", \"I\", \"C90\", \"W\"]\` — covers the old flake8 \`--select=E9,F63,F7,F82\` syntax set plus pycodestyle warnings, pyflakes, isort-equivalent import ordering, and mccabe complexity.
- \`[tool.ruff.lint.mccabe].max-complexity = 20\` (matches the old flake8 \`--max-complexity=20\` cap).
- \`[tool.ruff.lint.isort].known-first-party = [\"jina_sagemaker\"]\`.

\`.github/workflows/ci.yml\`:
- Replaces the four black / isort / flake8 lint steps with two \`ruff\` steps: \`ruff format --check\` and \`ruff check\`. Same gating semantics; runs in seconds instead of pip-installing three tools.

\`.pre-commit-config.yaml\`:
- Switches from \`PyCQA/isort\` + \`psf/black\` to a single \`astral-sh/ruff-pre-commit\` repo with the \`ruff\` (lint) and \`ruff-format\` hooks.

\`README.md\`:
- Development section updated to reference \`ruff format\` / \`ruff check\` instead of \`black\` / \`isort\` / \`flake8\`.

Formatting churn (\`jina_sagemaker/client.py\`, \`jina_sagemaker/helper.py\`, \`tests/test_client.py\`, \`tests/test_helper.py\`):
- \`ruff format\` collapsed a handful of \`with\`-statements that \`black\` had wrapped across multiple lines, because they fit on a single 127-column line. Purely cosmetic.

## Changes Outside the Codebase

None.

## Testing

\`pytest -q\` → 51 passed (the modernization PRs from #58 / #59 / #60 are the baseline).
\`ruff format --check .\` → 7 files already formatted.
\`ruff check .\` → All checks passed.

## Additional Information

- Notebooks and examples are excluded from ruff. Their cell ordering legitimately has imports interleaved with documentation cells (which ruff would flag as E402), and their formatting is curated separately.
- The \`extend-exclude\` list is the same scope flake8 was previously running against (it already excluded everything outside \`jina_sagemaker/\` and \`tests/\` via \`paths-ignore\` on the workflow trigger; this just centralises that decision into the tool config).