### PR TITLE
build: revert PyPI publish to token auth, bump to 0.0.47

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,18 +47,16 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/project/jina-sagemaker/
-    permissions:
-      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
-      - name: Publish to PyPI via Trusted Publishing
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.TWINE_USERNAME }}
+          password: ${{ secrets.TWINE_PASSWORD }}
 
   github-release:
     needs: publish

--- a/jina_sagemaker/__init__.py
+++ b/jina_sagemaker/__init__.py
@@ -1,5 +1,5 @@
 from .client import Client, InputType, Task
 
-__version__ = '0.0.46'
+__version__ = '0.0.47'
 
 __all__ = ["Client", "InputType", "Task", "__version__"]


### PR DESCRIPTION
## Context

PR #58 modernized the release workflow to use PyPI Trusted Publishing (OIDC), which avoids long-lived secrets on the GitHub side. However the PyPI side of that trust relationship was never configured for the \`jina-sagemaker\` project, so the first release attempt under the new workflow ([run 26654987397](https://github.com/jina-ai/jina-sagemaker/actions/runs/26654987397)) failed at the publish step with:

\`\`\`
invalid-publisher: valid token, but no corresponding publisher
(Publisher with matching claims was not found)
\`\`\`

Configuring the PyPI Trusted Publisher requires PyPI maintainer access to the project — rather than block on that, fall back to the long-standing \`TWINE_USERNAME\` / \`TWINE_PASSWORD\` repo secrets that have been in place since 2023 and worked for every prior release.

## Description

Only the publish step changes — tag-trigger, version verification, build, and github-release jobs are untouched.

## Changes in the Codebase

- \`.github/workflows/release.yml\`: publish step swaps OIDC config (the \`pypi\` environment + \`id-token: write\` permission) for explicit \`user\` / \`password\` inputs sourced from \`secrets.TWINE_USERNAME\` and \`secrets.TWINE_PASSWORD\`.
- \`jina_sagemaker/__init__.py\`: bump \`__version__\` to \`0.0.47\`. The existing \`v0.0.46\` tag points at the commit with the broken workflow, so a new tag is required to re-run the release end-to-end.

## Changes Outside the Codebase

None. \`TWINE_USERNAME\` and \`TWINE_PASSWORD\` already exist as repo secrets (configured 2023-09-18).

## Testing

Workflow change is config-only and will be exercised by the next release: after merge, tag \`v0.0.47\` and push to trigger the workflow.

## Additional Information

If a future maintainer wants to migrate back to Trusted Publishing, the path is:
1. On https://pypi.org/manage/project/jina-sagemaker/settings/publishing/ add a GitHub publisher with owner \`jina-ai\`, repo \`jina-sagemaker\`, workflow \`release.yml\`, environment \`pypi\`.
2. Revert this PR's workflow change.

Caveat: if the value stored in \`TWINE_PASSWORD\` is a stale account password rather than an API token, PyPI will still 403 (raw password auth was retired in 2024). Will know on the next tag push.