### PR TITLE
chore: release only on tag push, drop manual workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag to release (must already exist, e.g. v0.0.47)'
-        required: true
 
 jobs:
   build:
@@ -16,13 +11,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Verify tag matches package version
         env:
-          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          TAG: ${{ github.ref_name }}
         run: |
           PKG_VERSION=$(grep -E "^__version__" jina_sagemaker/__init__.py \
             | sed -E "s/.*['\"]([^'\"]+)['\"].*/\1/")
@@ -74,7 +69,7 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          TAG: ${{ github.ref_name }}
         run: |
           gh release create "$TAG" \
             --title "$TAG" \


### PR DESCRIPTION
## Context

The Release workflow supported two entry points: a `v*` tag push, and a manual `workflow_dispatch` whose `tag` input had to point at an already-existing tag. The manual path is a footgun: dispatching it for a tag that has not been cut yet fails immediately at `actions/checkout` (the ref does not resolve), which is exactly what happened on a recent attempt to release `v0.0.48` before the tag existed.

## Description

Remove the manual `workflow_dispatch` trigger so the Release workflow runs on exactly one path: pushing a `v*` tag. This is the canonical flow (bump `__version__`, then `git push origin vX.Y.Z`) and it cannot be invoked against a non-existent tag. A mid-pipeline failure on an existing tag can still be recovered by re-running the failed run from the Actions UI, so no capability is lost.

## Changes in the Codebase

- `.github/workflows/release.yml`:
  - Drop the `workflow_dispatch` trigger and its `tag` input. The workflow now triggers only on `push` of `v*` tags.
  - Simplify the now-dead `${{ github.event.inputs.tag || github.ref }}` / `${{ github.event.inputs.tag || github.ref_name }}` expressions to plain `${{ github.ref }}` / `${{ github.ref_name }}`, since the tag ref is always the trigger.

No behavioral change for the tag-push path: build, PyPI publish, and GitHub release run the same as before. The "Verify tag matches package version" guard is unchanged.

## Testing

- Validated the workflow YAML parses and the only remaining trigger is `push`.
- Confirmed no remaining references to `github.event.inputs`.

## Additional Information

The tag-push trigger fires automatically when a `v*` tag is pushed, so removing the manual dispatch does not change how releases are normally cut.
